### PR TITLE
feat: update path to JSON schema for globalConfig validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "jsonValidation": [
             {
                 "fileMatch": "globalConfig.json",
-                "url": "https://raw.githubusercontent.com/splunk/addonfactory-ucc-generator/master/splunk_add_on_ucc_framework/UCC-UI-lib/schema/schema.json"
+                "url": "https://raw.githubusercontent.com/splunk/addonfactory-ucc-base-ui/main/src/main/webapp/schema/schema.json"
             }
         ],
         "configuration": {


### PR DESCRIPTION
Creating this PR not to forget to change path to the schema file because of separating UI part from https://github.com/splunk/addonfactory-ucc-generator repository.
The current migration can be tracked here: https://github.com/splunk/addonfactory-ucc-generator/tree/ucc_ui_lib_migration.