### PR TITLE
feat: add new command to mimic debug refresh on SH

### DIFF
--- a/out/commands/reload.js
+++ b/out/commands/reload.js
@@ -1,0 +1,78 @@
+const vscode = require('vscode');
+
+const splunkUrl = vscode.workspace.getConfiguration().get('splunk.commands.splunkRestUrl');
+const splunkToken = vscode.workspace.getConfiguration().get('splunk.commands.token');
+const enableCertificateVerification = vscode.workspace
+    .getConfiguration()
+    .get('splunk.commands.enableCertificateVerification');
+const https = require('https');
+const axios = require('axios');
+
+axios.defaults.headers.common['Authorization'] = `Bearer ${splunkToken}`;
+
+const agent = new https.Agent({
+    rejectUnauthorized: enableCertificateVerification,
+});
+
+async function fullDebugRefresh(splunkOutputChannel) {
+    /* Similar to debug/refresh - this command reloads all reloadable EAI handlers minus auth-services */
+
+    const outputMode = 'json';
+
+    try {
+        /* Query for all /services/admin handlers */
+        const adminResponse = await axios({
+            method: 'GET',
+            url: `${splunkUrl}/services/admin?output_mode=${outputMode}`,
+            httpsAgent: agent,
+        });
+        /* Query for all UI handlers */
+        const dataResponse = await axios({
+            method: 'GET',
+            url: `${splunkUrl}/services/data/ui?output_mode=${outputMode}`,
+            httpsAgent: agent,
+        });
+
+        let jsonResult = await adminResponse.data;
+        const dataResult = await dataResponse.data;
+        jsonResult['entry'] = jsonResult['entry'].concat(dataResult['entry']);
+
+        /* Identify which handlers can be reloaded */
+        const reloadable = jsonResult['entry'].filter((entry) => {
+            return '_reload' in entry['links'] && entry['name'] !== 'auth-services';
+        });
+
+        const reloadRequests = reloadable.map(async (entry) => {
+            return await axios({
+                method: 'POST',
+                url: `${splunkUrl}${entry['links']['_reload']}`,
+                httpsAgent: agent,
+            });
+        });
+
+        /* Reload all handlers */
+        const results = await Promise.allSettled(reloadRequests);
+        vscode.window.showInformationMessage(`Performed _reload on ${results.length} EAI handlers`);
+    } catch (error) {
+        vscode.window.showErrorMessage(
+            `Could not enumerate handlers to refresh. ${error.message}`
+        );
+        return
+    }
+    /* Log results to Output */
+    splunkOutputChannel.appendLine(
+        results
+            .map((entry) => {
+                const status = entry.status == 'fulfilled' ? 'OK' : 'ERROR';
+                let endpoint =
+                    status == 'OK' ? entry.value.request.path : entry.reason.request.path;
+                endpoint = endpoint.replace('/services/', '').replace('/_reload', '');
+                return `Refreshing ${endpoint}: ${status}\n`;
+            })
+            .join('')
+    );
+
+    splunkOutputChannel.show();
+}
+
+exports.fullDebugRefresh = fullDebugRefresh;

--- a/out/commands/reload.js
+++ b/out/commands/reload.js
@@ -53,12 +53,7 @@ async function fullDebugRefresh(splunkOutputChannel) {
         /* Reload all handlers */
         const results = await Promise.allSettled(reloadRequests);
         vscode.window.showInformationMessage(`Performed _reload on ${results.length} EAI handlers`);
-    } catch (error) {
-        vscode.window.showErrorMessage(
-            `Could not enumerate handlers to refresh. ${error.message}`
-        );
-        return
-    }
+    
     /* Log results to Output */
     splunkOutputChannel.appendLine(
         results
@@ -73,6 +68,13 @@ async function fullDebugRefresh(splunkOutputChannel) {
     );
 
     splunkOutputChannel.show();
+    } 
+    catch (error) {
+        vscode.window.showErrorMessage(
+            `Could not enumerate handlers to refresh. ${error.message}`
+        );
+        return
+    }
 }
 
 exports.fullDebugRefresh = fullDebugRefresh;

--- a/out/extension.js
+++ b/out/extension.js
@@ -12,6 +12,8 @@ const splunkCustomCommand = require('./customCommand.js');
 const globalConfigPreview = require('./globalConfigPreview')
 const splunkCustomRESTHandler = require('./customRESTHandler.js')
 const splunkSpec = require("./spec.js");
+const reload = require("./commands/reload.js");
+
 //const { transpileModule } = require("typescript");
 //const { AsyncLocalStorage } = require("async_hooks");
 const PLACEHOLDER_REGEX = /\<([^\>]+)\>/g
@@ -188,6 +190,10 @@ function activate(context) {
         }
 
     }));
+
+    // Register Utility Commands
+
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.fullDebugRefresh', async () => {reload.fullDebugRefresh(splunkOutputChannel)}))
 
     // Set up stanza folding
     context.subscriptions.push(vscode.languages.registerFoldingRangeProvider([

--- a/package.json
+++ b/package.json
@@ -279,6 +279,11 @@
                 "title": "Preview globalConfig.json",
                 "category": "Splunk",
                 "enablement": "resourceFilename == globalConfig.json"
+            },
+            {
+                "command": "splunk.fullDebugRefresh",
+                "title": "Trigger Full Debug Refresh",
+                "category": "Splunk"
             }
         ]
     },


### PR DESCRIPTION
This PR adds a new command to the extension. It can be accessed from the command palette as 

> **Splunk: Trigger Full Debug Refresh**

The command will reload all reloadable splunkd EAI handlers, similar to the `debug/refresh` endpoint on Search Heads.
This is a common operation during development to ensure all `.conf` files are in effect.


Note that since the `debug/refresh` endpoint is only accessible on `:8000` and can't be authenticated against with a JWT, the command re-implements what the endpoint does under the covers.

First, it identifies all reloadable handlers and subsequently issues parallel POST requests to the respective endpoint. At the end, there will be a log to the Splunk Output Channel imitating, again, what `debug/refresh` returns. 
 
 https://user-images.githubusercontent.com/2430239/207841643-f394c15b-d462-4c75-aa96-534a570521a2.mp4
