### PR TITLE
Add ability to dispatch SPL2 via SPL2 Notebooks

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -15,9 +15,10 @@ const splunkSpec = require("./spec.js");
 const reload = require("./commands/reload.js");
 
 const notebookSerializers = require('./notebooks/serializers');
-const notebookControllers = require('./notebooks/controller');
+const notebookController = require('./notebooks/controller');
+const notebookSpl2Controller = require('./notebooks/spl2/controller');
 const notebookCommands = require('./notebooks/commands');
-const notebookProviders = require('./notebooks/provider');
+const notebookProvider = require('./notebooks/provider');
 
 //const { transpileModule } = require("typescript");
 //const { AsyncLocalStorage } = require("async_hooks");
@@ -227,10 +228,14 @@ function activate(context) {
 
     // Notebook
     context.subscriptions.push(vscode.workspace.registerNotebookSerializer('splunk-notebook', new notebookSerializers.SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
-	let controller = new notebookControllers.SplunkController()
-    context.subscriptions.push(controller)
-    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('splunk-notebook', new notebookProviders.CellResultCountStatusBarProvider(splunkOutputChannel)));
-    notebookCommands.registerNotebookCommands(controller, splunkOutputChannel, context)
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new notebookSerializers.SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
+    const controller = new notebookController.SplunkController();
+    context.subscriptions.push(controller);
+    const spl2Controller = new notebookSpl2Controller.Spl2Controller();
+    context.subscriptions.push(spl2Controller);
+    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('splunk-notebook', new notebookProvider.CellResultCountStatusBarProvider(splunkOutputChannel)));
+    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('spl2-notebook', new notebookProvider.CellResultCountStatusBarProvider(splunkOutputChannel)));
+    notebookCommands.registerNotebookCommands(controller, splunkOutputChannel, context);
 }
 exports.activate = activate;
 

--- a/out/extension.js
+++ b/out/extension.js
@@ -14,11 +14,11 @@ const splunkCustomRESTHandler = require('./customRESTHandler.js')
 const splunkSpec = require("./spec.js");
 const reload = require("./commands/reload.js");
 
-const notebookSerializers = require('./notebooks/serializers');
-const notebookController = require('./notebooks/controller');
-const notebookSpl2Controller = require('./notebooks/spl2/controller');
+const { SplunkNotebookSerializer } = require('./notebooks/serializers');
+const { SplunkController } = require('./notebooks/controller');
+const { Spl2Controller } = require('./notebooks/spl2/controller');
 const notebookCommands = require('./notebooks/commands');
-const notebookProvider = require('./notebooks/provider');
+const { CellResultCountStatusBarProvider } = require('./notebooks/provider');
 
 //const { transpileModule } = require("typescript");
 //const { AsyncLocalStorage } = require("async_hooks");
@@ -227,15 +227,15 @@ function activate(context) {
     }));
 
     // Notebook
-    context.subscriptions.push(vscode.workspace.registerNotebookSerializer('splunk-notebook', new notebookSerializers.SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
-	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new notebookSerializers.SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
-    const controller = new notebookController.SplunkController();
+    context.subscriptions.push(vscode.workspace.registerNotebookSerializer('splunk-notebook', new SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
+    const controller = new SplunkController();
     context.subscriptions.push(controller);
-    const spl2Controller = new notebookSpl2Controller.Spl2Controller();
+    const spl2Controller = new Spl2Controller();
     context.subscriptions.push(spl2Controller);
-    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('splunk-notebook', new notebookProvider.CellResultCountStatusBarProvider(splunkOutputChannel)));
-    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('spl2-notebook', new notebookProvider.CellResultCountStatusBarProvider(splunkOutputChannel)));
-    notebookCommands.registerNotebookCommands(controller, splunkOutputChannel, context);
+    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('splunk-notebook', new CellResultCountStatusBarProvider(splunkOutputChannel)));
+    context.subscriptions.push(vscode.notebooks.registerNotebookCellStatusBarItemProvider('spl2-notebook', new CellResultCountStatusBarProvider(splunkOutputChannel)));
+    notebookCommands.registerNotebookCommands([controller, spl2Controller], splunkOutputChannel, context);
 }
 exports.activate = activate;
 

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -3,9 +3,9 @@ import { SplunkController } from './controller';
 import { VIZ_TYPES } from './visualizations';
 import { getClient, getJobSearchLog, getSearchJobBySid } from './splunk';
 
-export async function registerNotebookCommands(controller: SplunkController, outputChannel: vscode.OutputChannel, context: vscode.ExtensionContext) {
+export async function registerNotebookCommands(controllers: SplunkController[], outputChannel: vscode.OutputChannel, context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.addVisualizationPreference', (cell) => { 
-		addVisualizationPreference(controller, cell)
+		controllers.forEach((controller) => addVisualizationPreference(controller, cell));
 	}))
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.openJobInspector', (sid) => { 

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -212,7 +212,8 @@ export class SplunkController {
             if (job.properties().isDone == true) {
                 jobComplete = true;
                 continue;
-            } 
+            }
+            execution.replaceOutput([new vscode.NotebookCellOutput([], { job: job.properties() })]);
             wait(1000);
         }        
 

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -11,12 +11,12 @@ import {
 import { splunkMessagesToOutputItems } from './utils';
 
 export class SplunkController {
-    readonly controllerId = 'splunk-notebook-controller';
-    readonly notebookType = 'splunk-notebook';
-    readonly label = 'SPL Note';
-    readonly supportedLanguages = ['markdown', 'splunk_search', 'splunk-spl-meta'];
+    protected controllerId: string;
+    protected notebookType: string;
+    protected label: string;
+    protected supportedLanguages: string[];
 
-    private readonly _controller: vscode.NotebookController;
+    protected _controller: vscode.NotebookController;
     private _executionOrder = 0;
     private _interrupted = false;
     private _tokens = {};
@@ -38,7 +38,17 @@ export class SplunkController {
     _lastjob: Contains the search id (sid) of the last query
     `;
 
-    constructor() {
+    constructor(
+            controllerId = 'splunk-notebook-controller',
+            notebookType = 'splunk-notebook',
+            label = 'SPL Note',
+            supportedLanguages = ['markdown', 'splunk_search', 'splunk-spl-meta']
+        ) {
+        this.controllerId = controllerId;
+        this.notebookType = notebookType;
+        this.label = label;
+        this.supportedLanguages = supportedLanguages;
+
         this._controller = vscode.notebooks.createNotebookController(
             this.controllerId,
             this.notebookType,
@@ -59,7 +69,7 @@ export class SplunkController {
         this._execute([cell], notebookDocument, this._controller);
     }
 
-    private _execute(
+    protected _execute(
         cells: vscode.NotebookCell[],
         _notebook: vscode.NotebookDocument,
         _controller: vscode.NotebookController
@@ -120,21 +130,23 @@ export class SplunkController {
         execution.end(true, Date.now());
     }
 
-    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+    protected _startExecution(cell: vscode.NotebookCell): vscode.NotebookCellExecution {
         this._interrupted = false;
         console.log(cell);
         const execution = this._controller.createNotebookCellExecution(cell);
         execution.executionOrder = ++this._executionOrder;
         execution.start(Date.now());
+        return execution;
+    }
+
+    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+        const execution = this._startExecution(cell);
 
         let query = cell.document.getText().trim().replace(/^\s+|\s+$/g, '');
 
         const service = getClient()
     
         let jobs = service.jobs();
-
-        let activeThemeKind = vscode.window.activeColorTheme.kind;
-        let backgroundColor = new vscode.ThemeColor('notebook.editorBackground');
 
         const tokenRegex = /\$([a-zA-Z0-9_.|]*?)\$/g;
 
@@ -171,7 +183,10 @@ export class SplunkController {
             execution.end(false, Date.now());
             return;
         }
-
+        await this._finishExecution(job, cell, execution);
+    }
+    
+    protected async _finishExecution(job: any, cell: vscode.NotebookCell, execution: vscode.NotebookCellExecution) {
         let sid = job['sid'];
         this._lastjob = sid;
         this._tokens['_lastjob'] = this._lastjob;
@@ -212,6 +227,8 @@ export class SplunkController {
 
         if (!this._interrupted) {
             let results: any = await getSearchJobResults(job);
+            let activeThemeKind = vscode.window.activeColorTheme.kind;
+            let backgroundColor = new vscode.ThemeColor('notebook.editorBackground');    
 
             execution.replaceOutput([
                 new vscode.NotebookCellOutput(

--- a/out/notebooks/provider.ts
+++ b/out/notebooks/provider.ts
@@ -15,7 +15,7 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
 
         const items: vscode.NotebookCellStatusBarItem[] = [];
 
-        if (cell.document.languageId !== "splunk_search") {
+        if (cell.document.languageId !== "splunk_search" && cell.document.languageId !== "splunk_spl2") {
             return items
         }
 

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -7,7 +7,6 @@ import {
 import { SplunkController } from '../controller';
 import { splunkMessagesToOutputItems } from '../utils';
 
-// TODO: refactor to inherit/compose with SplunkController for DRYness
 export class Spl2Controller extends SplunkController {
     constructor() {
         super('spl2-notebook-controller', 'spl2-notebook', 'SPL2 Note', ['splunk_spl2']);

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -1,76 +1,37 @@
 import * as vscode from 'vscode';
 
 import {
-    cancelSearchJob,
     dispatchSpl2Module,
     getClient,
-    getSearchJob,
-    getSearchJobResults,
-    wait,
 } from '../splunk';
+import { SplunkController } from '../controller';
 import { splunkMessagesToOutputItems } from '../utils';
 
 // TODO: refactor to inherit/compose with SplunkController for DRYness
-export class Spl2Controller {
-    readonly controllerId = 'spl2-notebook-controller';
-    readonly notebookType = 'spl2-notebook';
-    readonly label = 'SPL2 Note';
-    readonly supportedLanguages = ['splunk_spl2'];
-
-    private readonly _controller: vscode.NotebookController;
-    private _executionOrder = 0;
-    private _interrupted = false;
-
+export class Spl2Controller extends SplunkController {
     constructor() {
-        this._controller = vscode.notebooks.createNotebookController(
-            this.controllerId,
-            this.notebookType,
-            this.label,
-        );
-
-        this._controller.supportedLanguages = this.supportedLanguages;
-        this._controller.supportsExecutionOrder = true;
+        super('spl2-notebook-controller', 'spl2-notebook', 'SPL2 Note', ['splunk_spl2']);
         this._controller.executeHandler = this._execute.bind(this);
     }
 
-    dispose(): void {
-        this._controller.dispose();
-    }
-
-    async runCell(cell: vscode.NotebookCell) {
-        const notebookDocument = await vscode.workspace.openNotebookDocument(cell.document.uri)
-        this._execute([cell], notebookDocument, this._controller);
-    }
-
-    private _execute(
+    protected _execute(
         cells: vscode.NotebookCell[],
         _notebook: vscode.NotebookDocument,
         _controller: vscode.NotebookController
     ): void {
         for (let cell of cells) {
             if (cell.document.languageId == 'splunk_spl2') {
-                this._doExecution(cell);
+                this._doSpl2Execution(cell);
             }
         }
     }
 
-    async interruptHandler(notebook: vscode.NotebookDocument): Promise<void> {
-        console.log('interrupt handler called');
-    }
-
-    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
-        this._interrupted = false;
-        console.log(cell);
-        const execution = this._controller.createNotebookCellExecution(cell);
-        execution.executionOrder = ++this._executionOrder;
-        execution.start(Date.now());
+    private async _doSpl2Execution(cell: vscode.NotebookCell): Promise<void> {
+        const execution = super._startExecution(cell);
 
         const spl2Module = cell.document.getText().trim();
         const service = getClient();
     
-        let activeThemeKind = vscode.window.activeColorTheme.kind;
-        let backgroundColor = new vscode.ThemeColor('notebook.editorBackground');
-
         let job;
         try {
             job = await dispatchSpl2Module(service, spl2Module);
@@ -83,64 +44,6 @@ export class Spl2Controller {
             return;
         }
 
-        execution.replaceOutput([new vscode.NotebookCellOutput([], { job: job.properties() })]);
-
-        execution.token.onCancellationRequested(async () => {
-            this._interrupted = true;
-
-            let res: any = await cancelSearchJob(job);
-
-            const messageItems = splunkMessagesToOutputItems(res.data.messages);
-            execution.replaceOutput([new vscode.NotebookCellOutput(messageItems, { job: job.properties() })]);
-
-            execution.end(undefined, Date.now());
-        });
-
-        let jobComplete = false;
-
-        while (!jobComplete && !this._interrupted) {
-            job = await getSearchJob(job);
-
-            if (job.properties().isDone == true) {
-                jobComplete = true;
-                continue;
-            } 
-            wait(1000);
-        }        
-
-        if (job.properties().isFailed == true) {
-            const messages = job.properties().messages;
-            const messageItems = splunkMessagesToOutputItems(messages);
-
-            execution.replaceOutput([new vscode.NotebookCellOutput(messageItems, { job: job.properties() })]);
-            execution.end(false, Date.now());
-            return
-        }
-
-        if (!this._interrupted) {
-            let results: any = await getSearchJobResults(job);
-
-            execution.replaceOutput([
-                new vscode.NotebookCellOutput(
-                    [
-                        vscode.NotebookCellOutputItem.json(
-                            {
-                                results: results.data,
-                                _meta: {
-                                    backgroundColor: backgroundColor,
-                                    colorMode: activeThemeKind,
-                                    cellMeta: cell.metadata,
-                                },
-                            },
-                            'application/splunk/events'
-                        ),
-                        vscode.NotebookCellOutputItem.json(job.properties()),
-                    ],
-                    { job: job.properties() }
-                ),
-            ]);
-
-            execution.end(true, Date.now());
-        }
+        await super._finishExecution(job, cell, execution);
     }
 }

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -34,15 +34,18 @@ export class Spl2Controller extends SplunkController {
         let job;
         try {
             job = await dispatchSpl2Module(service, spl2Module);
+            await super._finishExecution(job, cell, execution);
         } catch (failedResponse) {
-            const messages = failedResponse.data.messages;
-            const messageItems = splunkMessagesToOutputItems(messages);
+            let outputItems: vscode.NotebookCellOutputItem[] = [];
+            if (!failedResponse.data || !failedResponse.data.messages) {
+                outputItems = [vscode.NotebookCellOutputItem.error(failedResponse)];
+            } else {
+                const messages = failedResponse.data.messages;
+                outputItems = splunkMessagesToOutputItems(messages);
+            }
 
-            execution.replaceOutput([new vscode.NotebookCellOutput(messageItems)]);
+            execution.replaceOutput([new vscode.NotebookCellOutput(outputItems)]);
             execution.end(false, Date.now());
-            return;
         }
-
-        await super._finishExecution(job, cell, execution);
     }
 }

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -1,6 +1,7 @@
 import * as splunk from 'splunk-sdk';
 import * as needle from 'needle'; // transitive dependency of splunk-sdk
 import * as vscode from 'vscode';
+import { SplunkMessage } from './utils';
 
 export function getClient() {
     const config = vscode.workspace.getConfiguration();
@@ -56,66 +57,95 @@ export function createSearchJob(jobs, query, options) {
 }
 
 export function dispatchSpl2Module(service: any, spl2Module: string) {
-    // Get first statement assignment '$my_statement = ...' -> 'my_statement' 
-    const statementMatch = spl2Module.match(/\$([a-zA-Z0-9_]+)[\s]*=/m);
-    if (!statementMatch || statementMatch.length < 2) {
+    // Get last statement assignment '$my_statement = ...' -> 'my_statement' 
+    const statementMatches = [...spl2Module.matchAll(/\$([a-zA-Z0-9_]+)[\s]*=/gm)];
+    if (!statementMatches
+        || statementMatches.length < 1
+        || statementMatches[statementMatches.length - 1].length < 2) {
         throw new Error(
             'No statements found in SPL2. Please assign at least one statement name ' +
             'using "$". For example: `$my_statement = from _internal`'
         );
     }
-    const statementIdentifier = statementMatch[1];
+    const statementIdentifier = statementMatches[statementMatches.length - 1][1];
 
     // The Splunk SDK for Javascript doesn't currently support the spl2-module-dispatch endpoint
     // nor does it support sending requests in JSON format (only receiving responses), so
     // for now use the underlying needle library that the SDK uses for requests/responses
-    return new Promise(function(resolve, reject) {
-        needle.request(
-            'POST',
-            `${service.prefix}/services/search/spl2-module-dispatch?output_mode=json`,
-            {
-                'module': spl2Module,
-                'namespace': '',
-                'queryParameters': {
-                    [statementIdentifier]: {
-                        'timezone': 'Etc/UTC',
-                        'collectFieldSummary': true,
-                        'collectEventSummary': false,
-                        'collectTimeBuckets': false,
-                        'output_mode': 'json_cols',
-                        'status_buckets': 300,
-                    }
-                }
-            },
-            {
-                'headers': {
-                    'Authorization': `Bearer ${service.sessionKey}`,
-                    'Content-Type': 'application/json',
-                },
-                'followAllRedirects': true,
-                'timeout': 0,
-                'strictSSL': false,
-                'rejectUnauthorized' : false,
-            },
-            async function(err, response, data) {
-                if (err !== null) {
-                    reject(err);
-                } else {
-                    if (!Array.prototype.isPrototypeOf(data) || data.length < 0) {
-                        reject(`Invalid response: '${JSON.stringify(response.body)}'`);
-                    } else {
-                        const sid = data[0]['sid'];
-                        try {
-                            const job = await getSearchJobBySid(service, sid);
-                            resolve(job);
-                        } catch (err) {
-                            reject(err);
-                        }
-                    }
+    return needle(
+        'POST',
+        `${service.prefix}/services/search/spl2-module-dispatch`,
+        {
+            'module': spl2Module,
+            'namespace': '',
+            'queryParameters': {
+                [statementIdentifier]: {
+                    'timezone': 'Etc/UTC',
+                    'collectFieldSummary': true,
+                    'collectEventSummary': false,
+                    'collectTimeBuckets': false,
+                    'output_mode': 'json_cols',
+                    'status_buckets': 300,
                 }
             }
-        );
-    });
+        },
+        {
+            'headers': {
+                'Authorization': `Bearer ${service.sessionKey}`,
+                'Content-Type': 'application/json',
+            },
+            'followAllRedirects': true,
+            'timeout': 0,
+            'strictSSL': false,
+            'rejectUnauthorized' : false,
+        })
+        .then((response) => {
+            const data = response.body;
+            if (!Array.prototype.isPrototypeOf(data) || data.length < 1) {
+                // Response is not in expected successful format, let's handle a
+                // few different error cases and raise as expected messages format
+                let messages:SplunkMessage[] = [];
+                if (Object.prototype.isPrototypeOf(data)) {
+                    if (data.name === 'response'
+                        && Array.prototype.isPrototypeOf(data.children)) {
+                        // Reformat messages for errors such as unauthorized
+                        messages = data.children
+                            .filter((child) => child.name === 'messages')
+                            .flatMap((msgs) => msgs.children)
+                            .map((msg) => new Object({
+                                    'type': msg?.attributes?.type,
+                                    'code': msg.name,
+                                    'text': msg.value,
+                            }));
+                    } else if (data.code !== undefined && data.message !== undefined) {
+                        // Reformat if returns a `code` and `message for errors such
+                        // as invalid request body format
+                        messages = [{
+                            'type': 'error',
+                            'code': data.code,
+                            'text': data.message,
+                        }];
+                    }
+                }
+                // If we still haven't handled this unsuccessful response then simply
+                // output the body as an error message
+                if (messages.length === 0) {
+                    messages = [{
+                        'type': 'error',
+                        'code': '',
+                        'text': `Error dispatching SPL2: ${JSON.stringify(data)}`,
+                    }];
+                }
+                throw new Object({
+                    'data': {
+                        'messages': messages,
+                    },
+                }); 
+            }
+            // This is in the expected successful response format
+            const sid = data[0]['sid'];
+            return getSearchJobBySid(service, sid);
+        });
 }
 
 export function getSearchJobBySid(service, sid) {

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -1,5 +1,6 @@
 import * as splunk from 'splunk-sdk';
-import * as vscode from 'vscode'
+import * as needle from 'needle'; // transitive dependency of splunk-sdk
+import * as vscode from 'vscode';
 
 export function getClient() {
     const config = vscode.workspace.getConfiguration();
@@ -20,7 +21,7 @@ export function getClient() {
         authorization: 'Bearer',
     });
 
-    return service
+    return service;
 }
 
 export function splunkLogin(service) {
@@ -29,42 +30,104 @@ export function splunkLogin(service) {
         
         service.login(function(err, wasSuccessful) {
             if (err !== null || !wasSuccessful) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(null)
+                resolve(null);
             }
-        })
+        });
 
-    })
+    });
 
 
 }
 
 
 export function createSearchJob(jobs, query, options) {
-
     return new Promise(function(resolve, reject) {
         jobs.create(query, options, function(err, data) {
             if (err !== null) {
                 reject(err);
             } else {
-                resolve(data)
+                resolve(data);
             }
-        })
+        });
 
-    })
+    });
+}
+
+export function dispatchSpl2Module(service: any, spl2Module: string) {
+    // Get first statement assignment '$my_statement = ...' -> 'my_statement' 
+    const statementMatch = spl2Module.match(/\$([a-zA-Z0-9_]+)[\s]*=/m);
+    if (!statementMatch || statementMatch.length < 2) {
+        throw new Error(
+            'No statements found in SPL2. Please assign at least one statement name ' +
+            'using "$". For example: `$my_statement = from _internal`'
+        );
+    }
+    const statementIdentifier = statementMatch[1];
+
+    // The Splunk SDK for Javascript doesn't currently support the spl2-module-dispatch endpoint
+    // nor does it support sending requests in JSON format (only receiving responses), so
+    // for now use the underlying needle library that the SDK uses for requests/responses
+    return new Promise(function(resolve, reject) {
+        needle.request(
+            'POST',
+            `${service.prefix}/services/search/spl2-module-dispatch?output_mode=json`,
+            {
+                'module': spl2Module,
+                'namespace': '',
+                'queryParameters': {
+                    [statementIdentifier]: {
+                        'timezone': 'Etc/UTC',
+                        'collectFieldSummary': true,
+                        'collectEventSummary': false,
+                        'collectTimeBuckets': false,
+                        'output_mode': 'json_cols',
+                        'status_buckets': 300,
+                    }
+                }
+            },
+            {
+                'headers': {
+                    'Authorization': `Bearer ${service.sessionKey}`,
+                    'Content-Type': 'application/json',
+                },
+                'followAllRedirects': true,
+                'timeout': 0,
+                'strictSSL': false,
+                'rejectUnauthorized' : false,
+            },
+            async function(err, response, data) {
+                if (err !== null) {
+                    reject(err);
+                } else {
+                    if (!Array.prototype.isPrototypeOf(data) || data.length < 0) {
+                        reject(`Invalid response: '${JSON.stringify(response.body)}'`);
+                    } else {
+                        const sid = data[0]['sid'];
+                        try {
+                            const job = await getSearchJobBySid(service, sid);
+                            resolve(job);
+                        } catch (err) {
+                            reject(err);
+                        }
+                    }
+                }
+            }
+        );
+    });
 }
 
 export function getSearchJobBySid(service, sid) {
     return new Promise(function(resolve, reject) {
         service.getJob(sid, function(err, data) {
             if (err != null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(data)
+                resolve(data);
             }
-        })
-    })
+        });
+    });
 }
 
 
@@ -72,52 +135,52 @@ export function getSearchJob(job) {
     return new Promise(function(resolve, reject) {
         job.fetch(function(err, job) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(job)
+                resolve(job);
             }
-        })
+        });
 
-    })
+    });
 }
 
 export function getJobSearchLog(job) {
     return new Promise(function(resolve, reject) {
         job.searchlog(function(err, log) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(log)
+                resolve(log);
             }
-        })
+        });
 
-    })
+    });
 }
 
 export function getSearchJobResults(job) {
     return new Promise(function(resolve, reject) {
         job.get("results", {"output_mode": "json_cols"},function(err, results) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(results)
+                resolve(results);
             }
-        })
+        });
 
-    })
+    });
 }
 
 export function cancelSearchJob(job) {
     return new Promise(function(resolve, reject) {
         job.cancel(function(err, results) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(results)
+                resolve(results);
             }
 
-        })
-    })
+        });
+    });
 }
 
 export function wait(ms = 1000) {

--- a/out/notebooks/utils.ts
+++ b/out/notebooks/utils.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-interface SplunkMessage {
+export interface SplunkMessage {
     type: string,
     code: string,
     text: string

--- a/package.json
+++ b/package.json
@@ -355,6 +355,9 @@
                 "selector": [
                     {
                         "filenamePattern": "*.spl2nb"
+                    },
+                    {
+                        "filenamePattern": "modules.json"
                     }
                 ]
             }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
                 ]
             },
             {
+                "id": "splunk_spl2",
+                "aliases": [
+                    "SPL2"
+                ],
+                "configuration": "./spl2-language-configuration.json",
+                "extensions": [
+                    ".spl2"
+                ]
+            },
+            {
                 "id": "splunk-spl-meta",
                 "aliases": [
                     "SPL-META"
@@ -69,6 +79,11 @@
                 "language": "splunk",
                 "scopeName": "source.splunk",
                 "path": "./syntaxes/splunk.tmLanguage.json"
+            },
+            {
+                "language": "splunk_spl2",
+                "scopeName": "source.spl2",
+                "path": "./syntaxes/spl2.tmGrammar.json"
             }
         ],
         "jsonValidation": [
@@ -330,6 +345,16 @@
                 "selector": [
                     {
                         "filenamePattern": "*.splnb"
+                    }
+                ]
+            },
+            {
+                "id": "spl2-notebook",
+                "type": "spl2-notebook",
+                "displayName": "SPL2 Notebook",
+                "selector": [
+                    {
+                        "filenamePattern": "*.spl2nb"
                     }
                 ]
             }

--- a/spl2-language-configuration.json
+++ b/spl2-language-configuration.json
@@ -1,0 +1,45 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*/\\*\\*(?!/)([^*]|\\*(?!/))*$",
+      "afterText": "^\\s*\\*/$",
+      "action": {
+        "indent": "indentOutdent",
+        "appendText": " * "
+      }
+    },
+    {
+      "beforeText": "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$",
+      "action": {
+        "indent": "none",
+        "appendText": " * "
+      }
+    },
+    {
+      "beforeText": "^(\t|[ ])*[ ]\\*([ ]([^*]|\\*(?!/))*)?$",
+      "oneLineAboveText": "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))/",
+      "action": {
+        "indent": "none",
+        "appendText": "* "
+      }
+    },
+    {
+      "beforeText": "^(\t|[ ])*[ ]\\*/\\s*$",
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    },
+    {
+      "beforeText": "^(\t|[ ])*[ ]\\*[^/]*\\*/\\s*$",
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    }
+  ]
+}

--- a/syntaxes/spl2.tmGrammar.json
+++ b/syntaxes/spl2.tmGrammar.json
@@ -1,0 +1,67 @@
+{
+  "scopeName": "source.spl2",
+  "patterns": [
+    {
+      "include": "#block_comment"
+    },
+    {
+      "include": "#line_comment"
+    },
+    {
+      "include": "#expression"
+    }
+  ],
+  "repository": {
+    "block_comment": {
+      "name": "comment.block.spl2",
+      "begin": "/\\*",
+      "end": "\\*/"
+    },
+    "line_comment": {
+      "name": "comment.line.double-slash.spl2",
+      "begin": "//",
+      "end": "$"
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#keyword"
+        },
+        {
+          "include": "#param"
+        },
+        {
+          "include": "#paren-expression"
+        }
+      ]
+    },
+    "keyword": {
+      "match": "\\b(between|BETWEEN|is|IS|like|LIKE'|and|AND|in|IN|not|NOT|or|OR|xor|XOR|after|apply|as|AS|asc|ASC|before|bin|branch|by|BY|dedup|desc|DESC|distinct|DISTINCT|eval|eventstats|exists|EXISTS|export|false|fit|from|FROM|function|group|GROUP|groupby|GROUPBY|having|HAVING|head|histperc|import|inner|INNER|into|join|JOIN|left|LEFT|limit|LIMIT|lookup|null|NULL|offset|OFFSET|on|ON|onchange|order|ORDER|orderby|ORDERBY|outer|OUTER|OUTPUT|OUTPUTNEW|rename|reset|return|rex|search|select|SELECT|sort|stats|streamstats|through|thru|timechart|timewrap|true|type|union|UNION|where|WHERE|while)\\b",
+      "name": "keyword"
+    },
+    "param": {
+      "match": "\\$[a-zA-Z0-9]+",
+      "name": "variable"
+    },
+    "paren-expression": {
+      "begin": "\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.paren.open"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.paren.close"
+        }
+      },
+      "name": "expression.group",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Building off the existing SPL Notes feature, provide new functionality to execute SPL2 as search jobs (for Splunk deployments supporting the `/services/search/spl2-module-dispatch` endpoint), and view results.

To try this out:
* Configure the following two [Extension Settings](https://github.com/splunk/vscode-extension-splunk/wiki/Extension-Settings) to point to a Splunk deployment which supports `/services/search/spl2-module-dispatch`:
  * `Splunk Rest Url`
  * `Token` 
* Open any file with the `.spl2nb` extension or files named `modules.json`.

![SPL2 Notes](https://github.com/fantavlik/vscode-extension-splunk/assets/4960530/25eaf9c1-5722-4cc2-8b8c-6791a274914a)

I also drafted this Wiki page to add once this work merges: https://github.com/fantavlik/vscode-extension-splunk/wiki/Splunk-Notebooks