### PR TITLE
Spl2 - Language Server Support

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -17,7 +17,7 @@ const reload = require("./commands/reload.js");
 const { SplunkNotebookSerializer } = require('./notebooks/serializers');
 const { SplunkController } = require('./notebooks/controller');
 const { Spl2Controller } = require('./notebooks/spl2/controller');
-const { getMissingSpl2Requirements, getLatestSpl2Release } = require('./notebooks/spl2/installer');
+const { installMissingSpl2Requirements, getLatestSpl2Release } = require('./notebooks/spl2/installer');
 const { startSpl2ClientAndServer } = require('./notebooks/spl2/initializer');
 const notebookCommands = require('./notebooks/commands');
 const { CellResultCountStatusBarProvider } = require('./notebooks/provider');
@@ -26,11 +26,11 @@ const { CellResultCountStatusBarProvider } = require('./notebooks/provider');
 //const { AsyncLocalStorage } = require("async_hooks");
 const PLACEHOLDER_REGEX = /\<([^\>]+)\>/g
 let specConfigs = {};
-let timeout = undefined;
-let diagnosticCollection = undefined;
-let specConfig = undefined;
+let timeout;
+let diagnosticCollection;
+let specConfig;
 let snippets = {};
-let spl2Client = undefined;
+let spl2Client;
 let spl2PortToAttempt = 59143; // 59143 ~ SPLNK if you squint really hard :)
 
 function getParentStanza(document, line) {
@@ -221,16 +221,16 @@ async function activate(context) {
                 await spl2Client.deactivate();
             }
             spl2Client = undefined;
-            await handleSpl2File(context, progressBar);
+            await handleSpl2Document(context, progressBar);
         } catch (err) {
             console.warn(`Error restarting SPL2 language server, err: ${err}`);
         }
     });
     if(vscode.window.activeTextEditor) {
-        if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
-            handleSplunkFile(context);
-        } else if (vscode.window.activeTextEditor.document.languageId == 'splunk_spl2') {
-            await handleSpl2File(context, progressBar);
+        if (isSplunkDocument(vscode.window.activeTextEditor.document)) {
+            handleSplunkDocument(context);
+        } else if (isSpl2Document(vscode.window.activeTextEditor.document)) {
+            await handleSpl2Document(context, progressBar);
         }
     }
 
@@ -247,10 +247,10 @@ async function activate(context) {
         if (!vscode.window.activeTextEditor) {
             return;
         }
-        if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
-            handleSplunkFile(context);
-        } else if (vscode.window.activeTextEditor.document.languageId == 'splunk_spl2') {
-            await handleSpl2File(context, progressBar);
+        if (isSplunkDocument(vscode.window.activeTextEditor.document)) {
+            handleSplunkDocument(context);
+        } else if (isSpl2Document(vscode.window.activeTextEditor.document)) {
+            await handleSpl2Document(context, progressBar);
         }
     }));
 
@@ -267,17 +267,17 @@ async function activate(context) {
 }
 exports.activate = activate;
 
-function isSplunkFile(fileName) {
+function isSplunkDocument(document) {
     let splunkFileExtensions = [".conf", "default.meta", "local.meta", "globalconfig.json"];
     for (let i=0; i < splunkFileExtensions.length; i++) {
-        if(fileName.toLowerCase().endsWith(splunkFileExtensions[i])) {
+        if(document.fileName.toLowerCase().endsWith(splunkFileExtensions[i])) {
             return true;
         }
     }
     return false;
 }
 
-function handleSplunkFile(context) {
+function handleSplunkDocument(context) {
 
     if(diagnosticCollection === undefined) {
         diagnosticCollection = vscode.languages.createDiagnosticCollection('splunk');
@@ -319,7 +319,11 @@ function handleSplunkFile(context) {
     specConfigs[currentDocument] = specConfig
 }
 
-async function handleSpl2File(context, progressBar) {
+function isSpl2Document(document) {
+    return document.languageId == 'splunk_spl2';
+}
+
+async function handleSpl2Document(context, progressBar) {
     if (spl2Client) {
         // Client and server are already running, try refreshing for case of new document
         const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1));
@@ -331,7 +335,7 @@ async function handleSpl2File(context, progressBar) {
         return;
     }
     try {
-        const installedLatestLsp = await getMissingSpl2Requirements(context, progressBar);
+        const installedLatestLsp = await installMissingSpl2Requirements(context, progressBar);
         if (!installedLatestLsp) {
             await getLatestSpl2Release(context, progressBar);
         }

--- a/out/extension.js
+++ b/out/extension.js
@@ -215,6 +215,17 @@ async function activate(context) {
     ], new splunkFoldingRangeProvider.confFoldingRangeProvider()));
 
     // If vscode was opened with an active Splunk file, handle it.
+    vscode.commands.registerCommand('splunk.restartSpl2LanguageServer', async () => {
+        try {
+            if (spl2Client) {
+                await spl2Client.deactivate();
+            }
+            spl2Client = undefined;
+            await handleSpl2File(context, progressBar);
+        } catch (err) {
+            console.warn(`Error restarting SPL2 language server, err: ${err}`);
+        }
+    });
     if(vscode.window.activeTextEditor) {
         if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
             handleSplunkFile(context);

--- a/out/extension.js
+++ b/out/extension.js
@@ -199,8 +199,12 @@ async function activate(context) {
 
     }));
 
-    // Register Utility Commands
+    // Setup progress bar for install
+    const progressBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+    context.subscriptions.push(progressBar);
+    progressBar.hide();
 
+    // Register Utility Commands
     context.subscriptions.push(vscode.commands.registerCommand('splunk.fullDebugRefresh', async () => {reload.fullDebugRefresh(splunkOutputChannel)}))
 
     // Set up stanza folding
@@ -213,7 +217,7 @@ async function activate(context) {
         if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
             handleSplunkFile(context);
         } else if (vscode.window.activeTextEditor.document.languageId == 'splunk_spl2') {
-            await handleSpl2File(context);
+            await handleSpl2File(context, progressBar);
         }
     }
 
@@ -233,7 +237,7 @@ async function activate(context) {
         if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
             handleSplunkFile(context);
         } else if (vscode.window.activeTextEditor.document.languageId == 'splunk_spl2') {
-            await handleSpl2File(context);
+            await handleSpl2File(context, progressBar);
         }
     }));
 
@@ -302,10 +306,10 @@ function handleSplunkFile(context) {
     specConfigs[currentDocument] = specConfig
 }
 
-async function handleSpl2File(context) {
+async function handleSpl2File(context, progressBar) {
     try {
-        await getMissingSpl2Requirements(context);
-        await getLatestSpl2Release(context);
+        await getMissingSpl2Requirements(context, progressBar);
+        await getLatestSpl2Release(context, progressBar);
         await startSpl2ClientAndServer(context);
     } catch (err) {
         vscode.window.showErrorMessage(`Issue setting up SPL2 environment: ${err}`);

--- a/out/extension.js
+++ b/out/extension.js
@@ -310,7 +310,13 @@ function handleSplunkFile(context) {
 
 async function handleSpl2File(context, progressBar) {
     if (spl2Client) {
-        // TODO: Client and server are already running, try refreshing for case of new document
+        // Client and server are already running, try refreshing for case of new document
+        const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1));
+        const text = vscode.window.activeTextEditor.document.getText(range) || " ";
+        vscode.window.activeTextEditor.edit((editBuilder) => {
+            // To refresh language server make a harmless edit by replacing the first character
+            editBuilder.replace(range, text);
+        });
         return;
     }
     try {
@@ -321,9 +327,9 @@ async function handleSpl2File(context, progressBar) {
         const onSpl2Restart = async (nextPort) => {
             await spl2Client.deactivate();
             spl2PortToAttempt = nextPort;
-            spl2Client = await startSpl2ClientAndServer(context, spl2PortToAttempt, onSpl2Restart);
+            spl2Client = await startSpl2ClientAndServer(context, progressBar, spl2PortToAttempt, onSpl2Restart);
         };
-        spl2Client = await startSpl2ClientAndServer(context, spl2PortToAttempt, onSpl2Restart);
+        spl2Client = await startSpl2ClientAndServer(context, progressBar, spl2PortToAttempt, onSpl2Restart);
     } catch (err) {
         vscode.window.showErrorMessage(`Issue setting up SPL2 environment: ${err}`);
     }

--- a/out/extension.js
+++ b/out/extension.js
@@ -308,8 +308,10 @@ function handleSplunkFile(context) {
 
 async function handleSpl2File(context, progressBar) {
     try {
-        await getMissingSpl2Requirements(context, progressBar);
-        await getLatestSpl2Release(context, progressBar);
+        const installedLatestLsp = await getMissingSpl2Requirements(context, progressBar);
+        if (!installedLatestLsp) {
+            await getLatestSpl2Release(context, progressBar);
+        }
         await startSpl2ClientAndServer(context);
     } catch (err) {
         vscode.window.showErrorMessage(`Issue setting up SPL2 environment: ${err}`);

--- a/out/extension.js
+++ b/out/extension.js
@@ -30,6 +30,7 @@ let timeout = undefined;
 let diagnosticCollection = undefined;
 let specConfig = undefined;
 let snippets = {};
+let spl2Client = undefined;
 
 function getParentStanza(document, line) {
     // Start at the passed in line and go backwards
@@ -312,7 +313,10 @@ async function handleSpl2File(context, progressBar) {
         if (!installedLatestLsp) {
             await getLatestSpl2Release(context, progressBar);
         }
-        await startSpl2ClientAndServer(context);
+        if (spl2Client) {
+            spl2Client.deactivate();
+        }
+        spl2Client = await startSpl2ClientAndServer(context);
     } catch (err) {
         vscode.window.showErrorMessage(`Issue setting up SPL2 environment: ${err}`);
     }
@@ -541,5 +545,10 @@ function getDiagnostics(specConfig, document) {
     return diagnostics;
 }
 
-function deactivate() { }
+function deactivate() {
+    if (spl2Client) {
+        return spl2Client.deactivate();
+    }
+}
+
 exports.deactivate = deactivate;

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -241,6 +241,7 @@ export class SplunkController {
                                     backgroundColor: backgroundColor,
                                     colorMode: activeThemeKind,
                                     cellMeta: cell.metadata,
+                                    languageId: cell?.document?.languageId,
                                 },
                             },
                             'application/splunk/events'

--- a/out/notebooks/renderer/components.jsx
+++ b/out/notebooks/renderer/components.jsx
@@ -15,7 +15,7 @@ box-shadow: 0;
     box-shadow: none !important;
 }
 `
-export default function VizSelector({value, onChange, isCollapsed}) {
+export default function VizSelector({value, onChange, isCollapsed, languageId}) {
 
     const [collapsed, setCollapsed] = useState(isCollapsed || false)
 
@@ -32,18 +32,19 @@ export default function VizSelector({value, onChange, isCollapsed}) {
         <div>
         {!collapsed &&
         <ButtonGroup tabIndex={-1} style={{"marginBottom": 10}}>
+            {/* Hide certain Viz options for SPL2 to focus use-case on developer audience */}
             <Button tabIndex={-1} selected={value == "events" ? true : false} onClick={() => onChange("events")}>Events</Button>
-            <Button tabIndex={-1} selected={value == "single" ? true : false}  onClick={() => onChange("single")}>Single</Button>
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "single" ? true : false}  onClick={() => onChange("single")}>Single</Button>}
             <Button tabIndex={-1} selected={value == "table" ? true : false}  onClick={() => onChange("table")}>Table</Button>
-            <Button tabIndex={-1} selected={value == "line" ? true : false}  onClick={() => onChange("line")}>Line</Button>
-            <Button tabIndex={-1} selected={value == "column" ? true : false}  onClick={() => onChange("column")}>Column</Button>
-            <Button tabIndex={-1} selected={value == "bar" ? true : false}  onClick={() => onChange("bar")}>Bar</Button>
-            <Button tabIndex={-1} selected={value == "area" ? true : false}  onClick={() => onChange("area")}>Area</Button>
-            <Button tabIndex={-1} selected={value == "pie" ? true : false}  onClick={() => onChange("pie")}>Pie</Button>
-            <Button tabIndex={-1} selected={value == "scatter" ? true : false}  onClick={() => onChange("scatter")}>Scatter</Button>
-            <Button tabIndex={-1} selected={value == "bubble" ? true : false}  onClick={() => onChange("bubble")}>Bubble</Button>
-            <Button tabIndex={-1} selected={value == "punchcard" ? true : false}  onClick={() => onChange("punchcard")}>Punchcard</Button>
-            <Button tabIndex={-1} selected={value == "link" ? true : false}  onClick={() => onChange("link")}>Link</Button>
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "line" ? true : false}  onClick={() => onChange("line")}>Line</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "column" ? true : false}  onClick={() => onChange("column")}>Column</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "bar" ? true : false}  onClick={() => onChange("bar")}>Bar</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "area" ? true : false}  onClick={() => onChange("area")}>Area</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "pie" ? true : false}  onClick={() => onChange("pie")}>Pie</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "scatter" ? true : false}  onClick={() => onChange("scatter")}>Scatter</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "bubble" ? true : false}  onClick={() => onChange("bubble")}>Bubble</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "punchcard" ? true : false}  onClick={() => onChange("punchcard")}>Punchcard</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "link" ? true : false}  onClick={() => onChange("link")}>Link</Button>}
         </ButtonGroup>}
         </div>
         <div>

--- a/out/notebooks/renderer/visualization.jsx
+++ b/out/notebooks/renderer/visualization.jsx
@@ -26,7 +26,7 @@ const StyledDiv = styled.div`
 } 
 `
 
-function VizViewer({data, backgroundColor, initialVizType, visualizationOptions}) {
+function VizViewer({data, backgroundColor, initialVizType, visualizationOptions, languageId}) {
 
     let initialType = "events"
  
@@ -100,7 +100,7 @@ function VizViewer({data, backgroundColor, initialVizType, visualizationOptions}
 
     return (
         <div>
-        <VizSelector isCollapsed={initialVizType !== undefined} onChange={handleChangeVizType} value={vizType} style={{"paddingBottom": "10px"}}></VizSelector>
+        <VizSelector isCollapsed={initialVizType !== undefined} onChange={handleChangeVizType} value={vizType} style={{"paddingBottom": "10px"}} languageId={languageId}></VizSelector>
 
         {viz}
         
@@ -115,6 +115,7 @@ export const activate= (_) => ({
 
         const visualizationPreference = _meta.cellMeta?.splunk?.visualizationPreference
         const visualizationOptions = _meta.cellMeta?.splunk?.visualizationOptions
+        const languageId = _meta?.languageId;
 
         console.log(visualizationOptions)
         //element.innerText = "H" + JSON.stringify(data.json())
@@ -127,7 +128,7 @@ export const activate= (_) => ({
         render(
             <SplunkThemeProvider family="prisma" colorScheme={colorScheme} density="compact">
                 <StyledDiv>
-                <VizViewer visualizationOptions={visualizationOptions} initialVizType={visualizationPreference} data={results} backgroundColor={_meta["backgroundColor"]}></VizViewer>
+                <VizViewer visualizationOptions={visualizationOptions} initialVizType={visualizationPreference} data={results} backgroundColor={_meta["backgroundColor"]} languageId={languageId}></VizViewer>
                 </StyledDiv>
         </SplunkThemeProvider>, element)
     },

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -2,11 +2,8 @@ import * as child_process from 'child_process';
 import { AddressInfo, Socket } from 'net';
 import * as path from 'path';
 import {
-    commands,
-	Disposable,
     ExtensionContext,
     StatusBarItem,
-    window,
     workspace,
 } from 'vscode';
 import {
@@ -177,8 +174,6 @@ export class Spl2ClientServer {
             // though in the future the compile command can be implemented
             // to compile to SPL1 which can then be run on any Splunk deployment
 
-            // this.context.subscriptions.push(new Disposable(() => this.killServer()));
-        
             // Start the client. This will also launch the server
             this.client.start();
 

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -284,19 +284,6 @@ export class Spl2ClientServer {
         }
         return Promise.resolve();
     }
-
-    // async retryConnection() {
-    //     if (this.retries++ > 10) {
-    //         window.showErrorMessage(`Issue setting up SPL2 environment, maxRetries reached.`);
-    //         return;
-    //     }
-    //     console.log('Retrying connection');
-    //     window.activeNotebookEditor.notebook
-    //     // commands.executeCommand('workbench.action.reloadWindow');
-        
-    //     // await this.client.stop();
-    //     // this.client.start();
-    // }
 }
 
 /**

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -2,7 +2,7 @@ import { ExtensionContext, workspace } from 'vscode';
 import {
     configKeyAcceptedTerms,
     configKeyJavaPath,
-    configKeyLSPVersion,
+    configKeyLspVersion,
     TermsAcceptanceStatus
 } from './installer';
 
@@ -18,7 +18,7 @@ export async function startSpl2ClientAndServer(context: ExtensionContext): Promi
             return;
         }
         const javaPath = workspace.getConfiguration().get(configKeyJavaPath);
-        const lspVersion = workspace.getConfiguration().get(configKeyLSPVersion);
+        const lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
         // TODO test for open port and start client and server
         reject('LSP initialization not implemented');
     });

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -1,0 +1,25 @@
+import { ExtensionContext, workspace } from 'vscode';
+import {
+    configKeyAcceptedTerms,
+    configKeyJavaPath,
+    configKeyLSPVersion,
+    TermsAcceptanceStatus
+} from './installer';
+
+export async function startSpl2ClientAndServer(context: ExtensionContext): Promise<void> {
+    return new Promise((resolve, reject) => {
+        // If the user has already opted-out for good then stop here
+        const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
+        if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
+            reject(
+                `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
+                `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
+            );
+            return;
+        }
+        const javaPath = workspace.getConfiguration().get(configKeyJavaPath);
+        const lspVersion = workspace.getConfiguration().get(configKeyLSPVersion);
+        // TODO test for open port and start client and server
+        reject('LSP initialization not implemented');
+    });
+}

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -1,25 +1,313 @@
-import { ExtensionContext, workspace } from 'vscode';
+import * as child_process from 'child_process';
+import { AddressInfo, Socket } from 'net';
+import * as path from 'path';
+import {
+    commands,
+	Disposable,
+    ExtensionContext,
+    workspace,
+} from 'vscode';
+import {
+	LanguageClient,
+	LanguageClientOptions,
+	ServerOptions,
+	State,
+	StreamInfo,
+} from 'vscode-languageclient/node';
+
 import {
     configKeyAcceptedTerms,
     configKeyJavaPath,
     configKeyLspVersion,
-    TermsAcceptanceStatus
+    getLocalLspDir,
+    getLspFilename,
+    TermsAcceptanceStatus,
 } from './installer';
 
-export async function startSpl2ClientAndServer(context: ExtensionContext): Promise<void> {
-    return new Promise((resolve, reject) => {
-        // If the user has already opted-out for good then stop here
-        const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
-        if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
-            reject(
-                `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
-                `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
-            );
-            return;
+interface ModuleItemId {
+	kind: string,
+	path: []
+}
+
+interface ResolveDatasetsParams {
+	user: string,
+	predicate: string,
+	ids: ModuleItemId[]
+}
+
+interface ResolveDataset {
+	owner: string,
+	kind: string,
+	id: string,
+	path: string[],
+	properties: Map<string, object>;
+}
+
+interface LSPLog {
+	timestamp: string,
+	level: string,
+	message: string,
+}
+
+export async function startSpl2ClientAndServer(context: ExtensionContext): Promise<Spl2ClientServer> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            // If the user has already opted-out for good then stop here
+            const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
+            if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
+                reject(
+                    `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
+                    `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
+                );
+                return;
+            }
+            const javaPath: string = workspace.getConfiguration().get(configKeyJavaPath);
+            if (!javaPath) {
+                reject(
+                    'Error initializing SPL2, please specify a java executable in the Splunk Extension ' +
+                    `Settings under '${configKeyJavaPath}'`
+                );
+                return;
+            }
+            const lspVersion: string = workspace.getConfiguration().get(configKeyLspVersion);
+            if (!lspVersion) {
+                reject(
+                    'Error initializing SPL2, please specify the language server version in the Splunk ' +
+                    `Extension Settings under '${configKeyLspVersion}'`
+                );
+                return;
+            }
+            const lspPath = path.join(getLocalLspDir(context), getLspFilename(lspVersion));
+            
+            const server = new Spl2ClientServer(context, javaPath, lspPath);
+            await server.initialize();
+            resolve(server);
+        } catch (err) {
+            reject(`Error initializing SPL2, err: ${err}`);
         }
-        const javaPath = workspace.getConfiguration().get(configKeyJavaPath);
-        const lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
-        // TODO test for open port and start client and server
-        reject('LSP initialization not implemented');
     });
 }
+
+export class Spl2ClientServer {
+    context: ExtensionContext;
+    javaPath: string;
+    lspPath: string;
+    // Set during initialize():
+    lspPort: number;
+    client: LanguageClient;
+    serverProcess: child_process.ChildProcess;
+
+    constructor(context:ExtensionContext, javaPath: string, lspPath: string) {
+        this.context = context;
+        this.javaPath = javaPath;
+        this.lspPath = lspPath;
+        this.lspPort = -1;
+        this.client = undefined;
+        this.serverProcess = undefined;
+    }
+
+    async initialize(): Promise<void> {
+        return new Promise(async (resolve, reject) => {
+            // 59143 ~ SPLNK if you squint really hard :)
+            this.lspPort = await getNextAvailablePort(59143, 10)
+                .catch((err) => {
+                    reject(`Unable to find available port for SPL2 language server`);
+                }) || -1;
+            if (this.lspPort === -1) {
+                reject(`Unable to find available port for SPL2 language server`);
+                return;
+            }
+
+            const serverOptions: ServerOptions = (): Promise<StreamInfo> => {
+                return new Promise((resolve, reject) => {
+                    const javaArgs: string[] = [
+                        '-Xmx2g',
+                        '-jar',
+                        this.lspPath,
+                        '--port',
+                        `${this.lspPort}`,
+                    ];
+                    this.serverProcess = child_process.spawn(this.javaPath, javaArgs);
+                    if (!this.serverProcess || !this.serverProcess.pid) {
+                        reject(`Launching server with ${this.javaPath} ${javaArgs.join(' ')} failed.`);
+                        return;
+                    } else {
+                        console.log(`SPL2 Language Server launched with pid: ${this.serverProcess.pid} and listening on port: ${this.lspPort}`);
+                    }
+                    this.serverProcess.stderr.on('data', stderr => {
+                        console.warn(`[SPL2 Server]: ${stderr}`);
+                    });
+                    this.serverProcess.stdout.on('data', stdout => {
+                        console.log(`[SPL2 Server]: ${stdout}`);
+                        const lspLog: LSPLog = JSON.parse(stdout);
+                        if (lspLog.message.includes('started listening on port')) {
+                            console.log('SPL2 Server is up, starting client...');
+                            // Ready for client
+                            const socket = new Socket();
+        
+                            socket.on('connect', () => {
+                                console.log('Client: connection established with server');
+                                const address:AddressInfo = socket.address() as AddressInfo;
+                                console.log(`Client is listening on port ${address.port}`);
+                                resolve({
+                                    writer: socket,
+                                    reader: socket,
+                                });
+                            });
+        
+                            socket.on('close', () => {
+                                setTimeout(() => {
+                                    // TODO: fail after X attempts rather than retrying indefinitely
+                                    console.log('Retrying connection');
+                                    commands.executeCommand('workbench.action.reloadWindow');
+                                }, 500);
+                            });
+        
+                            socket.on('error', (err) => {
+                                if (isNodeError(err) && err.code === 'ECONNRESET') {
+                                    // expected when server is killed
+                                    console.log('Server connection ended.');
+                                    return;
+                                }
+                                console.warn(`error between LSP client/server encountered -> ${err}`);
+                            });
+        
+                            socket.connect({
+                                port: this.lspPort,
+                            });
+                        }
+                    });
+                });
+            };
+        
+            // Options to control the language client
+            const clientOptions: LanguageClientOptions = {
+                documentSelector: [ 'spl' ],
+                initializationOptions: { profile: null }
+            };
+        
+            // Create the language client and start the client.
+            this.client = new LanguageClient(
+                'spl',
+                'SPL Language Client',
+                serverOptions,
+                clientOptions
+            );
+        
+            // Attach handlers for catalog item resolution.
+            this.client.onDidChangeState((event) => {
+                if (event.newState === State.Running) {
+                    this.client.onRequest('spl/resolveDatasets', (resolveDatasetsParams: ResolveDatasetsParams): ResolveDataset[] => {
+                        const id = resolveDatasetsParams.ids[0];
+                        // TODO: implement dataset resolution based on existing indexes/datasets within module
+                        return [];
+                    });
+        
+                    this.client.onRequest('spl/resolveModule', (): void => {
+                        // TODO: implement module resolution
+                        return;
+                    });
+                }
+            });
+        
+            // TODO: spl2/module and spl2/compile are not provided here,
+            // though in the future the compile command can be implemented
+            // to compile to SPL1 which can then be run on any Splunk deployment
+
+            this.context.subscriptions.push(new Disposable(() => this.killServer()));
+        
+            // Start the client. This will also launch the server
+            this.client.start();
+
+            resolve();
+        });
+    }
+
+    killServer(): void {
+        if (this.serverProcess && this.serverProcess.pid) {
+            console.log(`Terminating SPL2 Server pid ${this.serverProcess.pid} ...`);
+            this.serverProcess.kill();
+            this.serverProcess = undefined;
+        }
+    }
+  
+    deactivate(): Thenable<void> | undefined {
+        this.killServer();
+        if (!this.client) {
+            return undefined;
+        }
+        return this.client.stop();
+    }
+}
+  
+/**
+ * Helper to retrieve a socket using the supplied port and incrementing up
+ * to maxAttempts
+ * @param startPort Port to use to start testing with
+ * @param attempts How many attempts to increment port before failing (default: 10)
+ * @returns Promise<Socket> Socket with available port
+ */
+async function getNextAvailablePort(startPort: number, attempts: number): Promise<number> {
+    const maxAttempts = attempts || 10;
+    let attemptPort = startPort;
+    const isSocketInUse = (port: number): Promise<boolean> => {
+        return new Promise((resolve, reject) => {
+            const socket = new Socket();
+            socket.on('connect', () => {
+                // If we connect then this implies the port is in use and listening
+                socket.destroy();
+                console.log(`Port ${port} in use`);
+                resolve(true);
+            });
+    
+            const timeoutMs = 400;
+            socket.setTimeout(timeoutMs); // wait 400 ms before giving up
+            socket.on('timeout', () => {
+                // If we time out, assume port is unoccupied
+                socket.destroy();
+                console.log(`Port ${port} available (timeout)`);
+                resolve(false);
+            });
+  
+            socket.on('error', (err) => {
+                socket.destroy();
+                if (isNodeError(err) && err.code === 'ECONNREFUSED') {
+                    // no connection implies this is not in use
+                    console.log(`Port ${port} available`);
+                    resolve(false);
+                    return;
+                }
+                console.log(`Error connecting to ${port} err -> ${err}`);
+                reject(err); // otherwise we seem to be erroring out for other reasons
+            });
+  
+            console.log(`Trying port ${port} ...`);
+            socket.connect(port);
+      });
+    };
+  
+    let socketInUse = true;
+    while (socketInUse && attemptPort < startPort + maxAttempts) {
+        socketInUse = await isSocketInUse(attemptPort);
+        if (socketInUse) {
+            attemptPort++;
+        }
+    }
+    return new Promise((resolve, reject) => {
+        if (socketInUse) {
+            reject(`Unable to find available port after ${maxAttempts} attempts`);
+            return;
+        }
+        resolve(attemptPort);
+    });
+  }
+  
+  /**
+   * Convenience function to correctly type NodeJS errors that will
+   * have properties such as 'code' as opposed to vanilla JS errors.
+   * @param error Generic error to check for NodeJS.ErrnoException type
+   * @returns Bool if error is a NodeJS error with associated properties
+   */
+  function isNodeError(error: Error): error is NodeJS.ErrnoException {
+    return error instanceof Error;
+  }

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -182,14 +182,16 @@ export class Spl2ClientServer {
         
             // Options to control the language client
             const clientOptions: LanguageClientOptions = {
-                documentSelector: [ 'spl' ],
-                initializationOptions: { profile: null }
+                documentSelector: [
+                    { language: 'splunk_spl2' },
+                ],
+                initializationOptions: { profile: null },
             };
         
             // Create the language client and start the client.
             this.client = new LanguageClient(
-                'spl',
-                'SPL Language Client',
+                'spl2_client',
+                'SPL2 Language Client',
                 serverOptions,
                 clientOptions
             );

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -290,6 +290,7 @@ async function downloadWithProgress(
             method: 'GET',
             responseType: 'stream',
             transformRequest: (data, headers) => {
+                // Override defaults set elsewhere for splunkd communication
                 delete headers.common['Authorization'];
                 delete headers.common['Accept'];
                 return data;

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -64,7 +64,6 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
         // Setup local storage directory for downloads and installs
         makeLocalStorage(context);
         
-        const localJdkDir = path.join(context.globalStorageUri.fsPath, 'spl2', 'jdk');
         let installedLatestLsp = false;
         if (!lspVersion) {
             // If we haven't set up a Language Server version prompt use to accept terms
@@ -75,7 +74,12 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
                 return;
             }
             try {
-                await getLatestSpl2Release(context, progressBar);
+                // Remove any existing LSP artifacts first
+                const localLspDir = path.join(context.globalStorageUri.fsPath, 'spl2', 'lsp');
+                fs.rmdirSync(localLspDir, { recursive: true});
+                makeLocalStorage(context); // recreate directory
+            
+                // await getLatestSpl2Release(context, progressBar);
                 installedLatestLsp = true;
             } catch (err) {
                 reject(`Error retrieving latest SPL2 release, err: ${err}`);
@@ -89,6 +93,11 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
         }
         // We already prompted the user to confirm this download, proceed
         if (!javaLoc) {
+            // Remove any old artifacts first
+            const localJdkDir = path.join(context.globalStorageUri.fsPath, 'spl2', 'jdk');
+            fs.rmdirSync(localJdkDir, { recursive: true});
+            makeLocalStorage(context); // recreate directory
+
             javaLoc = await installJDK(localJdkDir, progressBar);
             workspace.getConfiguration().update(configKeyJavaPath, javaLoc);
         }

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -1,0 +1,53 @@
+import { ExtensionContext, workspace } from 'vscode';
+
+// Keys used to store/retrieve state related to this extension
+export const configKeyAcceptedTerms = 'splunk.spl2.acceptedTerms';
+export const configKeyJavaPath = 'splunk.spl2.javaPath';
+export const configKeyLSPVersion = 'splunk.spl2.languageServerVersion';
+
+export enum TermsAcceptanceStatus {
+    DeclinedForever = "declined (forever)",
+    DeclinedOnce = "declined (once)",
+    Accepted = "accepted",
+}
+
+export async function getMissingSpl2Requirements(context: ExtensionContext): Promise<void> {
+    return new Promise((resolve, reject) => {
+        // If the user has already opted-out for good then stop here
+        const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
+        if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
+            reject(
+                `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
+                `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
+            );
+            return;
+        }
+        // TODO:
+        // Check for compatible Java version installed already
+        //  a) JAVA_HOME first
+        //  b) JDK we installed in context.globalStorageUri.fsPath
+        // Check workspaceState for current LSP version
+        // Check to see LSP version exists on disk
+        // If LSP but no Java prompt for install
+        // If no LSP and no Java ask to accept terms and install both
+        // Record acceptance or denying of terms
+        // If accept
+        //   a) download and unpack JDK and update workspace config with location
+        //   b) download and unpack LSP and update workspace config with installedLSPVersion
+        reject('getMissingSpl2Requirements not implemented');
+    });
+}
+
+export async function getLatestSpl2Release(context: ExtensionContext): Promise<void> {
+    return new Promise((resolve, reject) => {
+        // TODO:
+        // Get lastChecked date from workspaceState
+        // if Date.now() - lastChecked > 1 day then
+        //   retrieve 
+        //   read metadata.versioning.latest value
+        // if latest version > installed version then prompt for download
+        // save update preference to workspace.getConfiguration
+        // if yes then download and unpack and update workspaceState with installedLSPVersion 
+        reject('getLatestSpl2Release not implemented');
+    });
+}

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -289,6 +289,11 @@ async function downloadWithProgress(
             url,
             method: 'GET',
             responseType: 'stream',
+            transformRequest: (data, headers) => {
+                delete headers.common['Authorization'];
+                delete headers.common['Accept'];
+                return data;
+              },
         })
         const totalSize = parseInt(headers['content-length']);
         let totalDownloaded = 0;
@@ -452,7 +457,7 @@ export async function getLatestSpl2Release(context: ExtensionContext, progressBa
                 const parser = new XMLParser();
                 const metadata = fs.readFileSync(metaPath);
                 const metaParsed = parser.parse(metadata);
-                lspVersion = metaParsed?.metadata?.versioning?.latest;
+                lspVersion = metaParsed?.metadata?.versioning?.release;
             } catch (err) {
                 console.warn(`Error retrieving latest SPL2 version, err: ${err}`);
             }

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -53,7 +53,7 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
         makeLocalStorage(context);
         
         // We still don't have Java installed, do it now
-        if (!javaLoc) {
+        if (!javaLoc || true) {
             const jdkDir = path.join(context.globalStorageUri.fsPath, "spl2", "jdk");
             javaLoc = await installJDK(jdkDir, progressBar);
         }
@@ -171,11 +171,11 @@ async function installJDK(installDir: string, progressBar: StatusBarItem): Promi
     const downloadedArchive = path.join(installDir, filename);
     await downloadWithProgress(url, downloadedArchive, progressBar);
 
-    // Extract
+    // Extract JDK and return path to java executable
+    let outPath;
     if (ext === 'zip') {
 
     } else { // tar.gz
-        let outPath;
         const pipe = util.promisify(pipeline);
         try {
             await pipe(
@@ -184,7 +184,7 @@ async function installJDK(installDir: string, progressBar: StatusBarItem): Promi
                 tar.extract(installDir, {
                     map: (header) => {
                         if (header.name.endsWith(path.join("bin", "java"))) {
-                            outPath = header.name;
+                            outPath = path.join(installDir, header.name);
                         }
                         return header;
                     }

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -73,6 +73,10 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
         } catch (err) {
             reject(`Error retrieving configuration '${configKeyLspVersion}', err: ${err}`);
         }
+        if (javaLoc && lspVersion) {
+            // Already set up, no need to continue
+            resolve(false);
+        }
         // Setup local storage directory for downloads and installs
         try {
             makeLocalStorage(context);
@@ -180,8 +184,12 @@ function getLocalJdkDir(context: ExtensionContext): string {
     return path.join(context.globalStorageUri.fsPath, 'spl2', 'jdk');
 }
 
-function getLocalLspDir(context: ExtensionContext): string {
+export function getLocalLspDir(context: ExtensionContext): string {
     return path.join(context.globalStorageUri.fsPath, 'spl2', 'lsp');
+}
+
+export function getLspFilename(lspVersion: string): string {
+    return `spl-lang-server-sockets-${lspVersion}-all.jar`;
 }
 
 async function promptToDownloadJava(): Promise<boolean> {
@@ -480,7 +488,7 @@ export async function getLatestSpl2Release(context: ExtensionContext, progressBa
                 console.warn(`Error retrieving latest SPL2 version, err: ${err}`);
             }
         }
-        const lspFilename = `spl-lang-server-sockets-${lspVersion}-all.jar`;
+        const lspFilename = getLspFilename(lspVersion);
         const localLspPath = path.join(getLocalLspDir(context), lspFilename);
         // Check if local file exists before downloading
         if (!fs.existsSync(localLspPath)) {

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -1,9 +1,17 @@
-import { ExtensionContext, workspace } from 'vscode';
+import axios from 'axios';
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { ExtensionContext, StatusBarItem, workspace } from 'vscode';
 
 // Keys used to store/retrieve state related to this extension
 export const configKeyAcceptedTerms = 'splunk.spl2.acceptedTerms';
 export const configKeyJavaPath = 'splunk.spl2.javaPath';
-export const configKeyLSPVersion = 'splunk.spl2.languageServerVersion';
+export const configKeyLspVersion = 'splunk.spl2.languageServerVersion';
+export const configKeyLspUrl = 'splunk.spl2.languageServerUrl';
+
+// Minimum version of Java needed for SPL2 Language Server
+const minimumMajorJavaVersion = 17;
 
 export enum TermsAcceptanceStatus {
     DeclinedForever = "declined (forever)",
@@ -11,8 +19,13 @@ export enum TermsAcceptanceStatus {
     Accepted = "accepted",
 }
 
-export async function getMissingSpl2Requirements(context: ExtensionContext): Promise<void> {
-    return new Promise((resolve, reject) => {
+/**
+ * Provide a guided install experience for installing Java and SPL2 Language Server including
+ * accepting Splunk General terms. If compatible Java and Language Server is already installed
+ * this will be a no-op.
+ */
+export async function getMissingSpl2Requirements(context: ExtensionContext, progressBar: StatusBarItem): Promise<void> {
+    return new Promise(async (resolve, reject) => {
         // If the user has already opted-out for good then stop here
         const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
         if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
@@ -22,11 +35,36 @@ export async function getMissingSpl2Requirements(context: ExtensionContext): Pro
             );
             return;
         }
-        // TODO:
         // Check for compatible Java version installed already
-        //  a) JAVA_HOME first
-        //  b) JDK we installed in context.globalStorageUri.fsPath
-        // Check workspaceState for current LSP version
+        let javaLoc = workspace.getConfiguration().get(configKeyJavaPath);
+        // If java hasn't been set up, check $JAVA_HOME before downloading a JDK
+        if (!javaLoc && process.env.JAVA_HOME) {
+            let javaHomeBin = path.join(process.env.JAVA_HOME, 'bin', 'java');
+            if (isJavaVersionCompatible(javaHomeBin)) {
+                javaLoc = javaHomeBin;
+                workspace.getConfiguration().update(configKeyJavaPath, javaHomeBin);
+            }
+        }
+        // Setup local storage directory for downloads and installs
+        makeLocalStorage(context);
+        if (!javaLoc) {
+            const jdkDir = path.join(context.globalStorageUri.fsPath, "spl2", "jdk");
+            await installJDK(jdkDir, progressBar);
+        }
+
+        // Check workspace for current installed LSP version
+        let lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
+        if (!lspVersion) {
+            // If we haven't set up a Language Server version prompt use to accept terms
+            // and also install java if needed
+
+            const lspUrl = workspace.getConfiguration().get(configKeyLspUrl);
+
+        } else if (!javaLoc) {
+            // If only java is needed simply install this in the background, no terms are needed
+
+            // TODO install java
+        }
         // Check to see LSP version exists on disk
         // If LSP but no Java prompt for install
         // If no LSP and no Java ask to accept terms and install both
@@ -38,7 +76,133 @@ export async function getMissingSpl2Requirements(context: ExtensionContext): Pro
     });
 }
 
-export async function getLatestSpl2Release(context: ExtensionContext): Promise<void> {
+/**
+ * Helper function to run 'java -version' and parse the result to check if it
+ * meets out minimum Java major version
+ * @param javaLoc Location of java executable (e.g. value of $JAVA_HOME) 
+ * @returns true if running `java -version` returns a `version "X.Y.Z"` where X
+ *          meets out minimum Java major version
+ */
+function isJavaVersionCompatible(javaLoc: string): boolean {
+    const javaVerCmd = child_process.spawnSync(javaLoc, ['-version'], { encoding : 'utf8' });
+    if (!javaVerCmd || javaVerCmd.stdout) {
+        return false;
+    }
+    // java -version actually writes to stderr so check for a match there
+    const match = javaVerCmd.stderr.toString().match(/version \"([0-9]+)\.[0-9]+\.[0-9]\"/m);
+    return (match && match.length > 1 && (parseInt(match[1]) >= minimumMajorJavaVersion));
+}
+
+/**
+ * Create the local storage directory struture for storing SPL2 artifacts
+ * if they haven't already been created
+ */
+function makeLocalStorage(context: ExtensionContext): void {
+    // We are guaranteed to have read/write access to this directory
+    const localSplunkArtifacts = context.globalStorageUri.fsPath;
+    // Create this directory structure:
+    // .../User/globalStorage/splunk.splunk
+    // └── spl2
+    //     ├── jdk
+    //     └── lsp
+    if (!fs.existsSync(localSplunkArtifacts)) {
+        fs.mkdirSync(localSplunkArtifacts);
+    }
+    const spl2Artifacts = path.join(localSplunkArtifacts, "spl2");
+    if (!fs.existsSync(spl2Artifacts)) {
+        fs.mkdirSync(spl2Artifacts);
+    }
+    const jdkArtifacts = path.join(spl2Artifacts, "jdk");
+    if (!fs.existsSync(jdkArtifacts)) {
+        fs.mkdirSync(jdkArtifacts);
+    }
+    const lspArtifacts = path.join(spl2Artifacts, "lsp");
+    if (!fs.existsSync(lspArtifacts)) {
+        fs.mkdirSync(lspArtifacts);
+    }
+}
+
+/**
+ * Helper function to install appropriate JDK to run the SPL2 Language Server
+ * @param installDir Local directory file path to write JDK to
+ */
+async function installJDK(installDir: string, progressBar: StatusBarItem): Promise<void> {
+    let arch = '';
+    let os = '';
+    let ext = 'tar.gz';
+    // Determine architecture
+    switch(process.arch) {
+        case 'x64':
+            arch = process.arch;
+            break;
+        case 'arm64':
+            arch = 'aarch64';
+            break;
+        default:
+            throw new Error(
+                `No JDK found for architecture: '${process.arch}'. To continue ` +
+                `install a Java ${minimumMajorJavaVersion} or later JDK and configure ` +
+                `the location in the Splunk Extension Settings under '${configKeyJavaPath}'.`
+            );
+    }
+    // Determine OS/extension
+    switch(process.platform) {
+        case 'darwin':
+            os = 'macos';
+            break;
+        case 'win32':
+            os = 'windows';
+            ext = 'zip';
+            break;
+        default:
+            os = 'linux';
+    }
+    
+    const filename = `amazon-corretto-${minimumMajorJavaVersion}-${arch}-${os}-jdk.${ext}`;
+    const url = `https://corretto.aws/downloads/latest/${filename}`;
+    // Download to installDir
+    const downloadedArchive = path.join(installDir, filename);
+    const fileWriter = fs.createWriteStream(downloadedArchive);
+
+    return new Promise(async (resolve, reject) => {
+        const { data, headers } = await axios({
+            url,
+            method: 'GET',
+            responseType: 'stream',
+        })
+        const totalSize = parseInt(headers['content-length']);
+        let totalDownloaded = 0;
+        let nextUpdate = 1;
+        let error;
+        progressBar.show();
+        data.on('data', (chunk) => {
+            totalDownloaded += chunk.length;
+            let pct = Math.floor(totalDownloaded * 100 / totalSize);
+            if (pct === nextUpdate) {
+                progressBar.text = `Downloading JDK ${pct}%`;
+                nextUpdate++;
+            }
+        });
+        fileWriter.on('error', (err) => {
+            error = err;
+            fileWriter.close();
+            reject(err);
+        });
+        fileWriter.on('close', () => {
+            if (!error) {
+                progressBar.hide();
+                resolve();
+            }
+        });
+        data.pipe(fileWriter);
+    });
+}
+
+/**
+ * Checks if the installed SPL2 Language Server version is the latest and prompt for
+ * upgrade if not, or automatically upgrade if user has that setting enabled.
+ */
+export async function getLatestSpl2Release(context: ExtensionContext, progressBar: StatusBarItem): Promise<void> {
     return new Promise((resolve, reject) => {
         // TODO:
         // Get lastChecked date from workspaceState

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -201,8 +201,6 @@ async function promptToDownloadJava(): Promise<boolean> {
     const userSelection = (await popup) || null;
     switch(userSelection) {
         case downloadAndInstallChoice:
-            // Record preference so user is not asked again
-            workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.Accepted, true);
             return true;
         case turnOffSPL2Choice:
             console.log('User opted out of SPL2 Langauge Server download, SPL2 support disabled');
@@ -436,6 +434,8 @@ async function promptToDownloadLsp(alsoInstallJava: boolean): Promise<boolean> {
     const userSelection = (await popup) || null;
     switch(userSelection) {
         case agreeAndContinueChoice:
+            // Record preference so user is not asked again
+            workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.Accepted, true);
             return true;
         case viewTermsChoice:
             console.log('Viewing Splunk General Terms in browser...');

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -14,7 +14,6 @@ import * as zlib from 'zlib';
 export const configKeyAcceptedTerms = 'splunk.spl2.acceptedTerms';
 export const configKeyJavaPath = 'splunk.spl2.javaPath';
 export const configKeyLspVersion = 'splunk.spl2.languageServerVersion';
-export const configKeyLspUrl = 'splunk.spl2.languageServerUrl';
 
 export const stateKeyLatestLspVersion = 'splunk.spl2.latestLspVersion';
 export const stateKeyLastLspCheck = 'splunk.spl2.lastLspCheck';
@@ -86,7 +85,6 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
             // If we haven't set up a Language Server version prompt use to accept terms
             // and also confirm install of java if needed
             try {
-                const lspUrl = workspace.getConfiguration().get(configKeyLspUrl);
                 const accepted = await promptToDownloadLsp(!javaLoc);
                 if (!accepted) {
                     return;
@@ -203,6 +201,8 @@ async function promptToDownloadJava(): Promise<boolean> {
     const userSelection = (await popup) || null;
     switch(userSelection) {
         case downloadAndInstallChoice:
+            // Record preference so user is not asked again
+            workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.Accepted, true);
             return true;
         case turnOffSPL2Choice:
             console.log('User opted out of SPL2 Langauge Server download, SPL2 support disabled');
@@ -210,7 +210,7 @@ async function promptToDownloadJava(): Promise<boolean> {
             workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.DeclinedForever, true);
             return false;
         default:
-            // Cancel
+            // Cancel, record no preference
             return false;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "splunk",
-    "version": "0.2.10",
+    "version": "0.2.11-beta1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "splunk",
-            "version": "0.2.10",
+            "version": "0.2.11-beta1",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-env": "^7.20.2",
@@ -26,7 +26,8 @@
                 "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
                 "typescript": "^4.2.2",
-                "unzipper": "^0.10.14"
+                "unzipper": "^0.10.14",
+                "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.1",
@@ -12362,6 +12363,60 @@
             "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
             "peer": true
         },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+        },
         "node_modules/vscode-test": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -22265,6 +22320,53 @@
             "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
             "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
             "peer": true
+        },
+        "vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+        },
+        "vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "requires": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "requires": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
         },
         "vscode-test": {
             "version": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "react-dom": "^16.14.0",
                 "splunk-sdk": "^1.12.1",
                 "styled-components": "5",
+                "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
                 "typescript": "^4.2.2"
             },
@@ -4320,8 +4321,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "peer": true
+            ]
         },
         "node_modules/batch-processor": {
             "version": "1.0.0",
@@ -4371,7 +4371,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "peer": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -4382,7 +4381,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -4478,7 +4476,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -4704,6 +4701,11 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "node_modules/chroma-js": {
             "version": "2.4.2",
@@ -5612,7 +5614,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "peer": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -6462,6 +6463,11 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "node_modules/fs-extra": {
             "version": "8.1.0",
@@ -8934,6 +8940,11 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "node_modules/mocha": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
@@ -9917,7 +9928,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "peer": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -11737,6 +11747,45 @@
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/temp": {
@@ -15914,8 +15963,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "peer": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "batch-processor": {
             "version": "1.0.0",
@@ -15953,7 +16001,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "peer": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -15964,7 +16011,6 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "peer": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -16026,7 +16072,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "peer": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -16184,6 +16229,11 @@
                     }
                 }
             }
+        },
+        "chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "chroma-js": {
             "version": "2.4.2",
@@ -16934,7 +16984,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "peer": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -17584,6 +17633,11 @@
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "peer": true
+        },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "fs-extra": {
             "version": "8.1.0",
@@ -19571,6 +19625,11 @@
                 "minimist": "^1.2.6"
             }
         },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "mocha": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
@@ -20319,7 +20378,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "peer": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -21753,6 +21811,41 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+        },
+        "tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "temp": {
             "version": "0.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@types/vscode-notebook-renderer": "^1.72.0",
                 "axios": ">=0.27.2",
                 "babel-loader": "^9.1.0",
+                "fast-xml-parser": "^4.2.4",
                 "react": "^16",
                 "react-dom": "^16.14.0",
                 "splunk-sdk": "^1.12.1",
@@ -6245,6 +6246,27 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-xml-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -11649,6 +11671,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "node_modules/styled-components": {
             "version": "5.1.1",
@@ -17459,6 +17486,14 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "fast-xml-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "requires": {
+                "strnum": "^1.0.5"
+            }
+        },
         "fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -21724,6 +21759,11 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
+        },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "styled-components": {
             "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
                 "styled-components": "5",
                 "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
-                "typescript": "^4.2.2"
+                "typescript": "^4.2.2",
+                "unzipper": "^0.10.14"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.1",
@@ -4332,7 +4333,6 @@
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -4349,7 +4349,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -4393,8 +4392,7 @@
         "node_modules/bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -4490,7 +4488,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
             "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -4499,7 +4496,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
             "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.2.0"
             }
@@ -4631,7 +4627,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
             },
@@ -5556,7 +5551,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
@@ -6505,7 +6499,6 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -6520,7 +6513,6 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -7728,8 +7720,7 @@
         "node_modules/listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -11076,8 +11067,7 @@
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -11984,7 +11974,6 @@
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -12208,10 +12197,9 @@
             }
         },
         "node_modules/unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
             "dependencies": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -15973,8 +15961,7 @@
         "big-integer": {
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
         },
         "bignumber.js": {
             "version": "8.1.1",
@@ -15985,7 +15972,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
             "requires": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -16022,8 +16008,7 @@
         "bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -16085,14 +16070,12 @@
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
         },
         "buffers": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
         },
         "bytes": {
             "version": "3.0.0",
@@ -16183,7 +16166,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
             }
@@ -16932,7 +16914,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
             }
@@ -17665,7 +17646,6 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -17677,7 +17657,6 @@
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -18620,8 +18599,7 @@
         "listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
         },
         "loader-runner": {
             "version": "4.3.0",
@@ -21267,8 +21245,7 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "setprototypeof": {
             "version": "1.2.0",
@@ -21992,8 +21969,7 @@
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
         },
         "ts-loader": {
             "version": "9.4.2",
@@ -22153,10 +22129,9 @@
             }
         },
         "unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
             "requires": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "splunk",
-    "version": "0.2.11-beta1",
+    "version": "0.2.10",
     "publisher": "Splunk",
     "engines": {
         "vscode": "^1.72.0"

--- a/package.json
+++ b/package.json
@@ -201,6 +201,13 @@
                     "default": "",
                     "order": 12,
                     "description": "[SPL2] Langauge Server Version"
+                },
+                "splunk.spl2.lsp.splunk.spl2.languageServerUrl": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 13,
+                    "description": "[SPL2] Langauge Server Download URL"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -438,7 +438,8 @@
         "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",
         "typescript": "^4.2.2",
-        "unzipper": "^0.10.14"
+        "unzipper": "^0.10.14",
+        "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "splunk",
-    "version": "0.2.10",
+    "version": "0.2.11-beta1",
     "publisher": "Splunk",
     "engines": {
         "vscode": "^1.72.0"
@@ -176,7 +176,7 @@
                     "order": 9,
                     "description": "When auto-completing settings, trim whitespace around the '=' sign. For example, key = value will become key=value.\nNote: changing this setting requires a restart of Visual Studio Code."
                 },
-                "splunk.spl2.lsp.splunk.spl2.acceptedTerms": {
+                "splunk.spl2.acceptedTerms": {
                     "type": "string",
                     "enum": [
                         "accepted",
@@ -188,21 +188,21 @@
                     "order": 10,
                     "description": "[SPL2] Accepted Splunk General Terms"
                 },
-                "splunk.spl2.lsp.splunk.spl2.javaPath": {
+                "splunk.spl2.javaPath": {
                     "type": "string",
                     "scope": "resource",
                     "default": "",
                     "order": 11,
                     "description": "[SPL2] Java Path"
                 },
-                "splunk.spl2.lsp.splunk.spl2.languageServerVersion": {
+                "splunk.spl2.languageServerVersion": {
                     "type": "string",
                     "scope": "resource",
                     "default": "",
                     "order": 12,
                     "description": "[SPL2] Langauge Server Version"
                 },
-                "splunk.spl2.lsp.splunk.spl2.languageServerUrl": {
+                "splunk.spl2.languageServerUrl": {
                     "type": "string",
                     "scope": "resource",
                     "default": "",

--- a/package.json
+++ b/package.json
@@ -361,6 +361,10 @@
             {
                 "command": "splunk.notebooks.copyDetection",
                 "title": "Copy Detection"
+            },
+            {
+                "command": "splunk.restartSpl2LanguageServer",
+                "title": "Restart SPL2 Language Server"
             }
         ],
         "notebooks": [

--- a/package.json
+++ b/package.json
@@ -443,7 +443,8 @@
         "styled-components": "5",
         "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.2.2",
+        "unzipper": "^0.10.14"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -175,6 +175,32 @@
                     "default": false,
                     "order": 9,
                     "description": "When auto-completing settings, trim whitespace around the '=' sign. For example, key = value will become key=value.\nNote: changing this setting requires a restart of Visual Studio Code."
+                },
+                "splunk.spl2.lsp.splunk.spl2.acceptedTerms": {
+                    "type": "string",
+                    "enum": [
+                        "accepted",
+                        "declined (once)",
+                        "declined (forever)"
+                    ],
+                    "scope": "resource",
+                    "default": "declined (once)",
+                    "order": 10,
+                    "description": "[SPL2] Accepted Splunk General Terms"
+                },
+                "splunk.spl2.lsp.splunk.spl2.javaPath": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 11,
+                    "description": "[SPL2] Java Path"
+                },
+                "splunk.spl2.lsp.splunk.spl2.languageServerVersion": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 12,
+                    "description": "[SPL2] Langauge Server Version"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -201,13 +201,6 @@
                     "default": "",
                     "order": 12,
                     "description": "[SPL2] Langauge Server Version"
-                },
-                "splunk.spl2.languageServerUrl": {
-                    "type": "string",
-                    "scope": "resource",
-                    "default": "",
-                    "order": 13,
-                    "description": "[SPL2] Langauge Server Download URL"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -437,6 +437,7 @@
         "@types/vscode-notebook-renderer": "^1.72.0",
         "axios": ">=0.27.2",
         "babel-loader": "^9.1.0",
+        "fast-xml-parser": "^4.2.4",
         "react": "^16",
         "react-dom": "^16.14.0",
         "splunk-sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -441,6 +441,7 @@
         "react-dom": "^16.14.0",
         "splunk-sdk": "^1.12.1",
         "styled-components": "5",
+        "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",
         "typescript": "^4.2.2"
     },


### PR DESCRIPTION
This PR unlocks the following features:
- Initialize a single SPL2 Language Server (java process spawned by the extension) and client
- Provide language server features such as autocomplete, hover documentation, syntax errors, etc
- Use a single language server for multiple documents, this requires a slight trick to keep the language server up-to-date after switching documents which we do by providing a no-op edit to the open file (replace the first character with itself when switching between documents)
- Provide support for automatically recovering when connection lost to server
- New command to allow the user to forcibly restart the language server if issues are encountered

To see the changes just for the intialization work (there's a separate PR https://github.com/splunk/vscode-extension-splunk/pull/86 for language server install) take a look at this diff, or you can focus on the initializer.ts file: https://github.com/fantavlik/vscode-extension-splunk/compare/spl2-install...fantavlik:vscode-extension-splunk:spl2-initialize

Demo of language server initialization:
![spl2-initialize](https://github.com/splunk/vscode-extension-splunk/assets/4960530/84df8115-ba89-48e6-8cce-052fb495e459)


Demo of a user restarting the language server via the custom command after a hard failure (killing the process spawned by the extension):
![spl2-kill-server](https://github.com/splunk/vscode-extension-splunk/assets/4960530/0c122e73-5b68-4974-ae98-35a7d383e61e)
