### PR TITLE
Spl2 fixes

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -16,6 +16,7 @@ const reload = require("./commands/reload.js");
 
 const { SplunkNotebookSerializer } = require('./notebooks/serializers');
 const { SplunkController } = require('./notebooks/controller');
+const { Spl2NotebookSerializer } = require('./notebooks/spl2/serializer');
 const { Spl2Controller } = require('./notebooks/spl2/controller');
 const { installMissingSpl2Requirements, getLatestSpl2Release } = require('./notebooks/spl2/installer');
 const { startSpl2ClientAndServer } = require('./notebooks/spl2/initializer');
@@ -256,7 +257,7 @@ async function activate(context) {
 
     // Notebook
     context.subscriptions.push(vscode.workspace.registerNotebookSerializer('splunk-notebook', new SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
-	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new Spl2NotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
     const controller = new SplunkController();
     context.subscriptions.push(controller);
     const spl2Controller = new Spl2Controller();

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -4,25 +4,36 @@ import { VIZ_TYPES } from './visualizations';
 import { getClient, getJobSearchLog, getSearchJobBySid } from './splunk';
 
 export async function registerNotebookCommands(controllers: SplunkController[], outputChannel: vscode.OutputChannel, context: vscode.ExtensionContext) {
-    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.addVisualizationPreference', (cell) => { 
-		controllers.forEach((controller) => addVisualizationPreference(controller, cell));
-	}))
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.addVisualizationPreference', (cell) => {
+		controllers.filter((controller) => (cell.notebook.notebookType === controller.notebookType))
+            .forEach((controller) => addVisualizationPreference(controller, cell));
+	}));
+
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.enterEarliestTime', (cell) => { 
+		controllers.filter((controller) => (cell.notebook.notebookType === controller.notebookType))
+            .forEach((controller) => enterEarliestTime(controller, cell));
+	}));
+
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.enterLatestTime', (cell) => { 
+		controllers.filter((controller) => (cell.notebook.notebookType === controller.notebookType))
+            .forEach((controller) => enterLatestTime(controller, cell));
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.openJobInspector', (sid) => { 
 		openJobInspector(sid)
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.openSearchLog', (cell) => { 
 		openSearchLog(cell, outputChannel)
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.copyJobIdToClipboard', (cell) => { 
 		copyJobIdToClipboard(cell)
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.copyDetection', (detection) => { 
 		copyDetection(detection)
-	}))
+	}));
 }
 
 
@@ -110,6 +121,64 @@ export async function addVisualizationPreference(
 
     await vscode.workspace.applyEdit(edit);
     await controller.runCell(cell);
+}
+
+export async function enterEarliestTime(
+    controller: SplunkController,
+    cell: vscode.NotebookCell
+) {
+    const cellMetadata = { ...cell.metadata };
+    if (!cellMetadata.splunk) {
+        cellMetadata.splunk = {};
+    }
+
+    let value = await vscode.window.showInputBox({
+        title: 'Earliest time',
+        value: cellMetadata.splunk.earliestTime || '-24h',
+        prompt: 'e.g. -24h, @d, -2d@d+2h, 1687909025',
+    });
+
+    if (value === undefined) { // canceled
+        return;
+    }
+    
+    cellMetadata.splunk.earliestTime = value;
+
+    const edit = new vscode.WorkspaceEdit();
+    const nbEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, cellMetadata);
+
+    edit.set(cell.notebook.uri, [nbEdit]);
+
+    await vscode.workspace.applyEdit(edit);
+}
+
+export async function enterLatestTime(
+    controller: SplunkController,
+    cell: vscode.NotebookCell
+) {
+    const cellMetadata = { ...cell.metadata };
+    if (!cellMetadata.splunk) {
+        cellMetadata.splunk = {};
+    }
+
+    let value = await vscode.window.showInputBox({
+        title: 'Latest time',
+        value: cellMetadata.splunk.latestTime || 'now',
+        prompt: 'e.g. now, -24h, @d, -2d@d+2h, 1687909025',
+    });
+
+    if (value === undefined) { // canceled
+        return;
+    }
+    
+    cellMetadata.splunk.latestTime = value;
+
+    const edit = new vscode.WorkspaceEdit();
+    const nbEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, cellMetadata);
+
+    edit.set(cell.notebook.uri, [nbEdit]);
+
+    await vscode.workspace.applyEdit(edit);
 }
 
 export async function copyJobIdToClipboard(cell) {

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -11,8 +11,9 @@ import {
 import { splunkMessagesToOutputItems } from './utils';
 
 export class SplunkController {
+    public notebookType: string;
+
     protected controllerId: string;
-    protected notebookType: string;
     protected label: string;
     protected supportedLanguages: string[];
 

--- a/out/notebooks/provider.ts
+++ b/out/notebooks/provider.ts
@@ -38,6 +38,33 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
             },
         });
 
+        const earliestPicker = {
+            text: 'earliest',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Earliest time',
+            command: {
+                title: 'Enter Earliest time',
+                command: 'splunk.notebooks.enterEarliestTime',
+                arguments: [cell],
+            },
+        };
+
+        const latestPicker = {
+            text: 'latest',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Latest time',
+            command: {
+                title: 'Enter Latest time',
+                command: 'splunk.notebooks.enterLatestTime',
+                arguments: [cell],
+            },
+        };
+        // earliest and latest time pickers are only supported for SPL2 at the moment
+        if (cell.document.languageId === 'splunk_spl2') {
+            items.push(earliestPicker);
+            items.push(latestPicker);
+        }
+
         if (cell.outputs.length === 1) {
             const meta = cell.outputs[0].metadata;
 
@@ -64,6 +91,11 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
                             "arguments": [cell]
                         }
                     });
+                    // earliest and latest time pickers are only supported for SPL2 at the moment
+                    if (cell.document.languageId === 'splunk_spl2') {
+                        items.push(earliestPicker);
+                        items.push(latestPicker);
+                    }
                     items.push({
                         tooltip: 'Dispatch State',
                         text: `$(gear) ${meta.job['dispatchState'] ? meta.job['dispatchState'].toLowerCase() : ''}`,

--- a/out/notebooks/serializers.ts
+++ b/out/notebooks/serializers.ts
@@ -16,7 +16,7 @@ interface RawNotebookCell {
     outputs?: RawCellOutput[];
 }
 
-function transformOutputFromCore(output: vscode.NotebookCellOutput): RawCellOutput {
+export function transformOutputFromCore(output: vscode.NotebookCellOutput): RawCellOutput {
 
     const cellOutput: RawCellOutput = {output_type: "execute_result", data: {}}
 
@@ -27,7 +27,7 @@ function transformOutputFromCore(output: vscode.NotebookCellOutput): RawCellOutp
     return cellOutput
 }
 
-function transformOutputToCore(rawOutput: RawCellOutput): vscode.NotebookCellOutput {
+export function transformOutputToCore(rawOutput: RawCellOutput): vscode.NotebookCellOutput {
     const cellOutput: vscode.NotebookCellOutput = new vscode.NotebookCellOutput([])
 
     for (const [key, value] of Object.entries(rawOutput.data)) {

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -33,7 +33,12 @@ export class Spl2Controller extends SplunkController {
     
         let job;
         try {
-            job = await dispatchSpl2Module(service, spl2Module);
+            job = await dispatchSpl2Module(
+                service,
+                spl2Module,
+                cell?.metadata?.splunk?.earliestTime,
+                cell?.metadata?.splunk?.latestTime,
+            );
             await super._finishExecution(job, cell, execution);
         } catch (failedResponse) {
             let outputItems: vscode.NotebookCellOutputItem[] = [];

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -431,7 +431,7 @@ async function extractTgzWithProgress(
                 if (header.name.endsWith(path.join('bin', 'java'))) {
                     binJavaPath = path.join(extractPath, header.name);
                 }
-                return Promise.resolve(header);
+                return header;
             }
         }),
     );

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -13,6 +13,7 @@ import * as zlib from 'zlib';
 // Keys used to store/retrieve state related to this extension
 export const configKeyAcceptedTerms = 'splunk.spl2.acceptedTerms';
 export const configKeyJavaPath = 'splunk.spl2.javaPath';
+export const configKeyLspDirectory = 'splunk.spl2.languageServerDirectory';
 export const configKeyLspVersion = 'splunk.spl2.languageServerVersion';
 
 export const stateKeyLatestLspVersion = 'splunk.spl2.latestLspVersion';
@@ -70,6 +71,10 @@ export async function installMissingSpl2Requirements(context: ExtensionContext, 
         let lspVersion;
         try {
             lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
+            if (!workspace.getConfiguration().get(configKeyLspDirectory)) {
+                const localLspDefault = path.join(context.globalStorageUri.fsPath, 'spl2', 'lsp');
+                await workspace.getConfiguration().update(configKeyLspDirectory, localLspDefault, true);
+            }
         } catch (err) {
             reject(`Error retrieving configuration '${configKeyLspVersion}', err: ${err}`);
         }
@@ -186,6 +191,10 @@ function getLocalJdkDir(context: ExtensionContext): string {
 }
 
 export function getLocalLspDir(context: ExtensionContext): string {
+    const configuredDir: string = workspace.getConfiguration().get(configKeyLspDirectory);
+    if (configuredDir) {
+        return configuredDir;
+    }
     return path.join(context.globalStorageUri.fsPath, 'spl2', 'lsp');
 }
 
@@ -478,46 +487,51 @@ async function promptToDownloadLsp(alsoInstallJava: boolean): Promise<boolean> {
  */
 export async function getLatestSpl2Release(context: ExtensionContext, progressBar: StatusBarItem): Promise<void> {
     return new Promise(async (resolve, reject) => {
-        const lspArtifactPath = path.join(context.globalStorageUri.fsPath, 'lsp');
+        const lspArtifactPath = getLocalLspDir(context);
         // TODO: Remove this hardcoded version/update time and check for updates
-        let lspVersion: string = '2.0.362'; // context.globalState.get(stateKeyLatestLspVersion) || "";
+        let latestLspVersion: string = '2.0.362'; // context.globalState.get(stateKeyLatestLspVersion) || "";
         const lastUpdateMs: number = Date.now(); // context.globalState.get(stateKeyLastLspCheck) || 0;
-        // Check for new version of SPL2 Language Server if longer than 24 hours
-        if (Date.now() - lastUpdateMs > 24 * 60 * 60 * 1000) {
-            const metaPath = path.join(lspArtifactPath, 'maven-metadata.xml');
-            try {
-                await downloadWithProgress(
-                    'https://splunk.jfrog.io/splunk/maven-splunk-release/spl2/com/splunk/spl/spl-lang-server-sockets/maven-metadata.xml',
-                    metaPath,
-                    progressBar,
-                    'Checking for SPL2 updates',
-                );
-                const parser = new XMLParser();
-                const metadata = fs.readFileSync(metaPath);
-                const metaParsed = parser.parse(metadata);
-                lspVersion = metaParsed?.metadata?.versioning?.release;
-            } catch (err) {
-                console.warn(`Error retrieving latest SPL2 version, err: ${err}`);
-            }
+        // Don't check for new version of SPL2 Language Server if less than 24 hours since last check
+        if (Date.now() - lastUpdateMs < 24 * 60 * 60 * 1000) {
+            resolve();
+            return;
         }
-        const lspFilename = getLspFilename(lspVersion);
+        const metaPath = path.join(lspArtifactPath, 'maven-metadata.xml');
+        try {
+            await downloadWithProgress(
+                'https://splunk.jfrog.io/splunk/maven-splunk-release/spl2/com/splunk/spl/spl-lang-server-sockets/maven-metadata.xml',
+                metaPath,
+                progressBar,
+                'Checking for SPL2 updates',
+            );
+            const parser = new XMLParser();
+            const metadata = fs.readFileSync(metaPath);
+            const metaParsed = parser.parse(metadata);
+            latestLspVersion = metaParsed?.metadata?.versioning?.release;
+        } catch (err) {
+            console.warn(`Error retrieving latest SPL2 version, err: ${err}`);
+        }
+        // Check if latest version has already been downloaded
+        const lspFilename = getLspFilename(latestLspVersion);
         const localLspPath = path.join(getLocalLspDir(context), lspFilename);
         // Check if local file exists before downloading
-        if (!fs.existsSync(localLspPath)) {
-            try {
-                await downloadWithProgress(
-                    `https://splunk.jfrog.io/splunk/maven-splunk/spl2/com/splunk/spl/spl-lang-server-sockets/${lspVersion}/${lspFilename}`,
-                    localLspPath,
-                    progressBar,
-                    'Downloading SPL2 Language Server',
-                );
-            } catch (err) {
-                reject(`Error downloading SPL2 Language Server, err: ${err}`);
-            }
+        if (fs.existsSync(localLspPath)) {
+            resolve();
+            return;
+        }
+        try {
+            await downloadWithProgress(
+                `https://splunk.jfrog.io/splunk/maven-splunk/spl2/com/splunk/spl/spl-lang-server-sockets/${latestLspVersion}/${lspFilename}`,
+                localLspPath,
+                progressBar,
+                'Downloading SPL2 Language Server',
+            );
+        } catch (err) {
+            reject(`Error downloading SPL2 Language Server, err: ${err}`);
         }
         // Update this setting to indicate that this version is ready-to-use
         try {
-            await workspace.getConfiguration().update(configKeyLspVersion, lspVersion, true);
+            await workspace.getConfiguration().update(configKeyLspVersion, latestLspVersion, true);
         } catch (err) {
             reject(`Error updating configuration '${configKeyLspVersion}', err: ${err}`);
         }

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -385,9 +385,9 @@ async function extractZipWithProgress(
         }
         readCompressedSize += entry.compressedSize;
         let pct = Math.floor(readCompressedSize * 100 / compressedSize);
-        if (pct === nextUpdate) {
+        if (pct >= nextUpdate) {
             progressBar.text = `${progressBarText} ${pct}%`;
-            nextUpdate++;
+            nextUpdate = pct + 1;
         }
     }});
     return Promise.resolve(binJavaPath);
@@ -411,9 +411,9 @@ async function extractTgzWithProgress(
         fs.createReadStream(tgzPath).on('data', (chunk) => {
             readCompressedSize += chunk.length;
             let pct = Math.floor(readCompressedSize * 100 / compressedSize);
-            if (pct === nextUpdate) {
+            if (pct >= nextUpdate) {
                 progressBar.text = `${progressBarText} ${pct}%`;
-                nextUpdate++;
+                nextUpdate = pct + 1;
             }
         }),
         zlib.createGunzip(),

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -37,7 +37,10 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
         try {
             raw = <Spl2ModulesJson>JSON.parse(contents);
         } catch {
-            raw = <Spl2ModulesJson>{};
+            raw = <Spl2ModulesJson>{
+                modules: [],
+                app: "apps.search",
+            };
         }
 
         const cells = raw.modules.map((module) => {

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -1,0 +1,79 @@
+import { TextDecoder, TextEncoder } from 'util';
+import {
+    RawCellOutput,
+    transformOutputFromCore,
+    transformOutputToCore,
+} from '../serializers';
+import * as vscode from 'vscode';
+
+// Hardcode a few values that will never change for SPL2 notebooks
+const spl2CellKind = vscode.NotebookCellKind.Code;
+const spl2CellLanguage = 'splunk_spl2';
+
+interface Spl2ModulesJson {
+    modules: Spl2ModuleCell[],
+    app: string, // hardcoded to apps.search for now
+}
+
+interface Spl2ModuleCell {
+    name: string; // hardcoded to module1, module2, etc for now
+    namespace: string; // hardcoded to "" for now
+    definition: string; // SPL2 statements
+    _vscode: {
+        metadata: { [key: string]: any };
+        outputs?: RawCellOutput[];
+    };
+}
+
+export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
+    async deserializeNotebook(
+        content: Uint8Array,
+        token: vscode.CancellationToken
+    ): Promise<vscode.NotebookData> {
+        var contents = new TextDecoder().decode(content);
+
+        let raw: Spl2ModulesJson;
+
+        try {
+            raw = <Spl2ModulesJson>JSON.parse(contents);
+        } catch {
+            raw = <Spl2ModulesJson>{};
+        }
+
+        const cells = raw.modules.map((module) => {
+            let newCell = new vscode.NotebookCellData(spl2CellKind, module.definition, spl2CellLanguage);
+
+            newCell.metadata = module._vscode.metadata || {};
+            newCell.outputs = module._vscode.outputs.map(output => transformOutputToCore(output))
+
+            return newCell;
+        });
+
+        return new vscode.NotebookData(cells);
+    }
+
+    async serializeNotebook(
+        data: vscode.NotebookData,
+        token: vscode.CancellationToken
+    ): Promise<Uint8Array> {
+        let contents: Spl2ModulesJson = <Spl2ModulesJson>{
+            modules: [],
+            app: "apps.search",
+        };
+
+        let indx = 1;
+        for (const cell of data.cells) {
+            contents.modules.push(<Spl2ModuleCell>{
+                name: `module${indx++}`,
+                namespace: "",
+                definition: cell.value,
+                _vscode: {
+                    metadata: cell.metadata,
+                    outputs: cell.outputs.map((output) => transformOutputFromCore(output)),
+                },
+            });
+        }
+
+        return new TextEncoder().encode(JSON.stringify(contents, null, 2));
+    }
+}

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -56,7 +56,7 @@ export function createSearchJob(jobs, query, options) {
     });
 }
 
-export function dispatchSpl2Module(service: any, spl2Module: string) {
+export function dispatchSpl2Module(service: any, spl2Module: string, earliest: string, latest: string) {
     // Get last statement assignment '$my_statement = ...' -> 'my_statement' 
     const statementMatches = [...spl2Module.matchAll(/\$([a-zA-Z0-9_]+)[\s]*=/gm)];
     if (!statementMatches
@@ -68,6 +68,20 @@ export function dispatchSpl2Module(service: any, spl2Module: string) {
         );
     }
     const statementIdentifier = statementMatches[statementMatches.length - 1][1];
+    const params = {
+        'timezone': 'Etc/UTC',
+        'collectFieldSummary': true,
+        'collectEventSummary': false,
+        'collectTimeBuckets': false,
+        'output_mode': 'json_cols',
+        'status_buckets': 300,
+    };
+    if (earliest !== undefined) {
+        params['earliest'] = earliest;
+    }
+    if (latest !== undefined) {
+        params['latest'] = latest;
+    }
 
     // The Splunk SDK for Javascript doesn't currently support the spl2-module-dispatch endpoint
     // nor does it support sending requests in JSON format (only receiving responses), so
@@ -79,14 +93,7 @@ export function dispatchSpl2Module(service: any, spl2Module: string) {
             'module': spl2Module,
             'namespace': '',
             'queryParameters': {
-                [statementIdentifier]: {
-                    'timezone': 'Etc/UTC',
-                    'collectFieldSummary': true,
-                    'collectEventSummary': false,
-                    'collectTimeBuckets': false,
-                    'output_mode': 'json_cols',
-                    'status_buckets': 300,
-                }
+                [statementIdentifier]: params
             }
         },
         {

--- a/package.json
+++ b/package.json
@@ -193,14 +193,21 @@
                     "scope": "resource",
                     "default": "",
                     "order": 11,
-                    "description": "[SPL2] Java Path"
+                    "description": "[SPL2] Java Path\nSpecify the full path to a Java executable (./java for Mac/Linux or java.exe for Windows). For example, the full path of $JAVA_HOME/bin/java."
+                },
+                "splunk.spl2.languageServerDirectory": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 12,
+                    "description": "[SPL2] Language Server Directory\nSpecify the full path of the directory containing SPL2 (Websockets) Langauge Server. Trailing slash not required. Example:\n/Users/<User>/Library/Application Support/Code/User/globalStorage/splunk.splunk/spl2/lsp"
                 },
                 "splunk.spl2.languageServerVersion": {
                     "type": "string",
                     "scope": "resource",
                     "default": "",
-                    "order": 12,
-                    "description": "[SPL2] Langauge Server Version"
+                    "order": 13,
+                    "description": "[SPL2] Language Server Version\nSpecify the version of the SPL2 language server which will be used to create the path to invoke the server. Example, a value of '2.0.362' will invoke spl-lang-server-sockets-2.0.362-all.jar"
                 }
             }
         },


### PR DESCRIPTION
- Provide better error handling and configurability for language server download and install by allowing user to specify custom path to LSP file
- Fix issue with progress bars getting stuck
- Allow users to input earliest and latest times
Demo:
![spl2-earliest-latest](https://github.com/splunk/vscode-extension-splunk/assets/4960530/dd1d0d22-1494-47f8-a4ee-ce1bd0474dc8)

- Serialize the format for SPL2 notebooks saved to disk to more closely match modules.json expectations, example:
```json
{
  "modules": [
    {
      "name": "module1",
      "namespace": "",
      "definition": "$q1 = from _internal where log_level != \"ERROR\"",
      "_vscode": {
        "metadata": {
          "splunk": {
            "earliestTime": "-24h",
            "latestTime": "now"
          }
        },
        "outputs": []
      }
    },
    {
      "name": "module2",
      "namespace": "",
      "definition": " $q2 = from main",
      "_vscode": {
        "metadata": {
          "splunk": {
            "earliestTime": "@d",
            "latestTime": "now"
          }
        },
        "outputs": []
      }
    }
  ],
  "app": "apps.search"
}
```