### PR TITLE
SPL2 Notebooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
       - main
       - master
       - develop
+      - spl2
 
 jobs:
   build:

--- a/out/extension.js
+++ b/out/extension.js
@@ -17,6 +17,8 @@ const reload = require("./commands/reload.js");
 const { SplunkNotebookSerializer } = require('./notebooks/serializers');
 const { SplunkController } = require('./notebooks/controller');
 const { Spl2Controller } = require('./notebooks/spl2/controller');
+const { getMissingSpl2Requirements, getLatestSpl2Release } = require('./notebooks/spl2/installer');
+const { startSpl2ClientAndServer } = require('./notebooks/spl2/initializer');
 const notebookCommands = require('./notebooks/commands');
 const { CellResultCountStatusBarProvider } = require('./notebooks/provider');
 
@@ -64,7 +66,7 @@ function getDocumentItems(document, PATTERN) {
     return items
 }
 
-function activate(context) {
+async function activate(context) {
 
     let splunkOutputChannel = vscode.window.createOutputChannel("Splunk");
 
@@ -197,8 +199,12 @@ function activate(context) {
 
     }));
 
-    // Register Utility Commands
+    // Setup progress bar for install
+    const progressBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+    context.subscriptions.push(progressBar);
+    progressBar.hide();
 
+    // Register Utility Commands
     context.subscriptions.push(vscode.commands.registerCommand('splunk.fullDebugRefresh', async () => {reload.fullDebugRefresh(splunkOutputChannel)}))
 
     // Set up stanza folding
@@ -207,8 +213,12 @@ function activate(context) {
     ], new splunkFoldingRangeProvider.confFoldingRangeProvider()));
 
     // If vscode was opened with an active Splunk file, handle it.
-    if(vscode.window.activeTextEditor && isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
-        handleSplunkFile(context);
+    if(vscode.window.activeTextEditor) {
+        if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
+            handleSplunkFile(context);
+        } else if (vscode.window.activeTextEditor.document.languageId == 'splunk_spl2') {
+            await handleSpl2File(context, progressBar);
+        }
     }
 
     // Set up listener for text document changes
@@ -220,9 +230,14 @@ function activate(context) {
     }));
 
     // Set up listener for active editor changing
-    context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor( () => {
-        if (vscode.window.activeTextEditor && isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
+    context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor( async () => {
+        if (!vscode.window.activeTextEditor) {
+            return;
+        }
+        if (isSplunkFile(vscode.window.activeTextEditor.document.fileName)) {
             handleSplunkFile(context);
+        } else if (vscode.window.activeTextEditor.document.languageId == 'splunk_spl2') {
+            await handleSpl2File(context, progressBar);
         }
     }));
 
@@ -289,6 +304,18 @@ function handleSplunkFile(context) {
 
     // Cache specConfig
     specConfigs[currentDocument] = specConfig
+}
+
+async function handleSpl2File(context, progressBar) {
+    try {
+        const installedLatestLsp = await getMissingSpl2Requirements(context, progressBar);
+        if (!installedLatestLsp) {
+            await getLatestSpl2Release(context, progressBar);
+        }
+        await startSpl2ClientAndServer(context);
+    } catch (err) {
+        vscode.window.showErrorMessage(`Issue setting up SPL2 environment: ${err}`);
+    }
 }
 
 function getSpecFilePath(basePath, filename) {

--- a/out/extension.js
+++ b/out/extension.js
@@ -16,6 +16,7 @@ const reload = require("./commands/reload.js");
 
 const { SplunkNotebookSerializer } = require('./notebooks/serializers');
 const { SplunkController } = require('./notebooks/controller');
+const { Spl2NotebookSerializer } = require('./notebooks/spl2/serializer');
 const { Spl2Controller } = require('./notebooks/spl2/controller');
 const { installMissingSpl2Requirements, getLatestSpl2Release } = require('./notebooks/spl2/installer');
 const { startSpl2ClientAndServer } = require('./notebooks/spl2/initializer');
@@ -256,7 +257,7 @@ async function activate(context) {
 
     // Notebook
     context.subscriptions.push(vscode.workspace.registerNotebookSerializer('splunk-notebook', new SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
-	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new SplunkNotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('spl2-notebook', new Spl2NotebookSerializer(), {transientCellMetadata: {inputCollapsed: true, outputCollapsed: true}, transientOutputs: false}));
     const controller = new SplunkController();
     context.subscriptions.push(controller);
     const spl2Controller = new Spl2Controller();

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -3,9 +3,9 @@ import { SplunkController } from './controller';
 import { VIZ_TYPES } from './visualizations';
 import { getClient, getJobSearchLog, getSearchJobBySid } from './splunk';
 
-export async function registerNotebookCommands(controller: SplunkController, outputChannel: vscode.OutputChannel, context: vscode.ExtensionContext) {
+export async function registerNotebookCommands(controllers: SplunkController[], outputChannel: vscode.OutputChannel, context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.addVisualizationPreference', (cell) => { 
-		addVisualizationPreference(controller, cell)
+		controllers.forEach((controller) => addVisualizationPreference(controller, cell));
 	}))
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.openJobInspector', (sid) => { 

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -4,25 +4,36 @@ import { VIZ_TYPES } from './visualizations';
 import { getClient, getJobSearchLog, getSearchJobBySid } from './splunk';
 
 export async function registerNotebookCommands(controllers: SplunkController[], outputChannel: vscode.OutputChannel, context: vscode.ExtensionContext) {
-    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.addVisualizationPreference', (cell) => { 
-		controllers.forEach((controller) => addVisualizationPreference(controller, cell));
-	}))
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.addVisualizationPreference', (cell) => {
+		controllers.filter((controller) => (cell.notebook.notebookType === controller.notebookType))
+            .forEach((controller) => addVisualizationPreference(controller, cell));
+	}));
+
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.enterEarliestTime', (cell) => { 
+		controllers.filter((controller) => (cell.notebook.notebookType === controller.notebookType))
+            .forEach((controller) => enterEarliestTime(controller, cell));
+	}));
+
+    context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.enterLatestTime', (cell) => { 
+		controllers.filter((controller) => (cell.notebook.notebookType === controller.notebookType))
+            .forEach((controller) => enterLatestTime(controller, cell));
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.openJobInspector', (sid) => { 
 		openJobInspector(sid)
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.openSearchLog', (cell) => { 
 		openSearchLog(cell, outputChannel)
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.copyJobIdToClipboard', (cell) => { 
 		copyJobIdToClipboard(cell)
-	}))
+	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand('splunk.notebooks.copyDetection', (detection) => { 
 		copyDetection(detection)
-	}))
+	}));
 }
 
 
@@ -110,6 +121,64 @@ export async function addVisualizationPreference(
 
     await vscode.workspace.applyEdit(edit);
     await controller.runCell(cell);
+}
+
+export async function enterEarliestTime(
+    controller: SplunkController,
+    cell: vscode.NotebookCell
+) {
+    const cellMetadata = { ...cell.metadata };
+    if (!cellMetadata.splunk) {
+        cellMetadata.splunk = {};
+    }
+
+    let value = await vscode.window.showInputBox({
+        title: 'Earliest time',
+        value: cellMetadata.splunk.earliestTime || '-24h',
+        prompt: 'e.g. -24h, @d, -2d@d+2h, 1687909025',
+    });
+
+    if (value === undefined) { // canceled
+        return;
+    }
+    
+    cellMetadata.splunk.earliestTime = value;
+
+    const edit = new vscode.WorkspaceEdit();
+    const nbEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, cellMetadata);
+
+    edit.set(cell.notebook.uri, [nbEdit]);
+
+    await vscode.workspace.applyEdit(edit);
+}
+
+export async function enterLatestTime(
+    controller: SplunkController,
+    cell: vscode.NotebookCell
+) {
+    const cellMetadata = { ...cell.metadata };
+    if (!cellMetadata.splunk) {
+        cellMetadata.splunk = {};
+    }
+
+    let value = await vscode.window.showInputBox({
+        title: 'Latest time',
+        value: cellMetadata.splunk.latestTime || 'now',
+        prompt: 'e.g. now, -24h, @d, -2d@d+2h, 1687909025',
+    });
+
+    if (value === undefined) { // canceled
+        return;
+    }
+    
+    cellMetadata.splunk.latestTime = value;
+
+    const edit = new vscode.WorkspaceEdit();
+    const nbEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, cellMetadata);
+
+    edit.set(cell.notebook.uri, [nbEdit]);
+
+    await vscode.workspace.applyEdit(edit);
 }
 
 export async function copyJobIdToClipboard(cell) {

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -241,6 +241,7 @@ export class SplunkController {
                                     backgroundColor: backgroundColor,
                                     colorMode: activeThemeKind,
                                     cellMeta: cell.metadata,
+                                    languageId: cell?.document?.languageId,
                                 },
                             },
                             'application/splunk/events'

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -11,18 +11,16 @@ import {
 import { splunkMessagesToOutputItems } from './utils';
 
 export class SplunkController {
-    readonly controllerId = 'splunk-notebook-controller';
-    readonly notebookType = 'splunk-notebook';
-    readonly label = 'SPL Note';
-    readonly supportedLanguages = ['markdown', 'splunk_search', 'splunk-spl-meta'];
+    protected controllerId: string;
+    protected notebookType: string;
+    protected label: string;
+    protected supportedLanguages: string[];
 
-    private readonly _controller: vscode.NotebookController;
+    protected _controller: vscode.NotebookController;
     private _executionOrder = 0;
     private _interrupted = false;
     private _tokens = {};
     private _lastjob = undefined;
-
-    readonly rendererScriptId = 'splunk-visualization-script';
 
     readonly _spl_meta_help = `
     SPL-META Manual
@@ -40,7 +38,17 @@ export class SplunkController {
     _lastjob: Contains the search id (sid) of the last query
     `;
 
-    constructor() {
+    constructor(
+            controllerId = 'splunk-notebook-controller',
+            notebookType = 'splunk-notebook',
+            label = 'SPL Note',
+            supportedLanguages = ['markdown', 'splunk_search', 'splunk-spl-meta']
+        ) {
+        this.controllerId = controllerId;
+        this.notebookType = notebookType;
+        this.label = label;
+        this.supportedLanguages = supportedLanguages;
+
         this._controller = vscode.notebooks.createNotebookController(
             this.controllerId,
             this.notebookType,
@@ -61,7 +69,7 @@ export class SplunkController {
         this._execute([cell], notebookDocument, this._controller);
     }
 
-    private _execute(
+    protected _execute(
         cells: vscode.NotebookCell[],
         _notebook: vscode.NotebookDocument,
         _controller: vscode.NotebookController
@@ -122,21 +130,23 @@ export class SplunkController {
         execution.end(true, Date.now());
     }
 
-    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+    protected _startExecution(cell: vscode.NotebookCell): vscode.NotebookCellExecution {
         this._interrupted = false;
         console.log(cell);
         const execution = this._controller.createNotebookCellExecution(cell);
         execution.executionOrder = ++this._executionOrder;
         execution.start(Date.now());
+        return execution;
+    }
+
+    private async _doExecution(cell: vscode.NotebookCell): Promise<void> {
+        const execution = this._startExecution(cell);
 
         let query = cell.document.getText().trim().replace(/^\s+|\s+$/g, '');
 
         const service = getClient()
     
         let jobs = service.jobs();
-
-        let activeThemeKind = vscode.window.activeColorTheme.kind;
-        let backgroundColor = new vscode.ThemeColor('notebook.editorBackground');
 
         const tokenRegex = /\$([a-zA-Z0-9_.|]*?)\$/g;
 
@@ -173,7 +183,10 @@ export class SplunkController {
             execution.end(false, Date.now());
             return;
         }
-
+        await this._finishExecution(job, cell, execution);
+    }
+    
+    protected async _finishExecution(job: any, cell: vscode.NotebookCell, execution: vscode.NotebookCellExecution) {
         let sid = job['sid'];
         this._lastjob = sid;
         this._tokens['_lastjob'] = this._lastjob;
@@ -199,7 +212,8 @@ export class SplunkController {
             if (job.properties().isDone == true) {
                 jobComplete = true;
                 continue;
-            } 
+            }
+            execution.replaceOutput([new vscode.NotebookCellOutput([], { job: job.properties() })]);
             wait(1000);
         }        
 
@@ -214,6 +228,8 @@ export class SplunkController {
 
         if (!this._interrupted) {
             let results: any = await getSearchJobResults(job);
+            let activeThemeKind = vscode.window.activeColorTheme.kind;
+            let backgroundColor = new vscode.ThemeColor('notebook.editorBackground');    
 
             execution.replaceOutput([
                 new vscode.NotebookCellOutput(

--- a/out/notebooks/controller.ts
+++ b/out/notebooks/controller.ts
@@ -11,8 +11,9 @@ import {
 import { splunkMessagesToOutputItems } from './utils';
 
 export class SplunkController {
+    public notebookType: string;
+
     protected controllerId: string;
-    protected notebookType: string;
     protected label: string;
     protected supportedLanguages: string[];
 

--- a/out/notebooks/provider.ts
+++ b/out/notebooks/provider.ts
@@ -15,7 +15,7 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
 
         const items: vscode.NotebookCellStatusBarItem[] = [];
 
-        if (cell.document.languageId !== "splunk_search") {
+        if (cell.document.languageId !== "splunk_search" && cell.document.languageId !== "splunk_spl2") {
             return items
         }
 

--- a/out/notebooks/provider.ts
+++ b/out/notebooks/provider.ts
@@ -38,6 +38,33 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
             },
         });
 
+        const earliestPicker = {
+            text: 'earliest',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Earliest time',
+            command: {
+                title: 'Enter Earliest time',
+                command: 'splunk.notebooks.enterEarliestTime',
+                arguments: [cell],
+            },
+        };
+
+        const latestPicker = {
+            text: 'latest',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Latest time',
+            command: {
+                title: 'Enter Latest time',
+                command: 'splunk.notebooks.enterLatestTime',
+                arguments: [cell],
+            },
+        };
+        // earliest and latest time pickers are only supported for SPL2 at the moment
+        if (cell.document.languageId === 'splunk_spl2') {
+            items.push(earliestPicker);
+            items.push(latestPicker);
+        }
+
         if (cell.outputs.length === 1) {
             const meta = cell.outputs[0].metadata;
 
@@ -64,6 +91,11 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
                             "arguments": [cell]
                         }
                     });
+                    // earliest and latest time pickers are only supported for SPL2 at the moment
+                    if (cell.document.languageId === 'splunk_spl2') {
+                        items.push(earliestPicker);
+                        items.push(latestPicker);
+                    }
                     items.push({
                         tooltip: 'Dispatch State',
                         text: `$(gear) ${meta.job['dispatchState'] ? meta.job['dispatchState'].toLowerCase() : ''}`,

--- a/out/notebooks/renderer/components.jsx
+++ b/out/notebooks/renderer/components.jsx
@@ -15,7 +15,7 @@ box-shadow: 0;
     box-shadow: none !important;
 }
 `
-export default function VizSelector({value, onChange, isCollapsed}) {
+export default function VizSelector({value, onChange, isCollapsed, languageId}) {
 
     const [collapsed, setCollapsed] = useState(isCollapsed || false)
 
@@ -32,18 +32,19 @@ export default function VizSelector({value, onChange, isCollapsed}) {
         <div>
         {!collapsed &&
         <ButtonGroup tabIndex={-1} style={{"marginBottom": 10}}>
+            {/* Hide certain Viz options for SPL2 to focus use-case on developer audience */}
             <Button tabIndex={-1} selected={value == "events" ? true : false} onClick={() => onChange("events")}>Events</Button>
-            <Button tabIndex={-1} selected={value == "single" ? true : false}  onClick={() => onChange("single")}>Single</Button>
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "single" ? true : false}  onClick={() => onChange("single")}>Single</Button>}
             <Button tabIndex={-1} selected={value == "table" ? true : false}  onClick={() => onChange("table")}>Table</Button>
-            <Button tabIndex={-1} selected={value == "line" ? true : false}  onClick={() => onChange("line")}>Line</Button>
-            <Button tabIndex={-1} selected={value == "column" ? true : false}  onClick={() => onChange("column")}>Column</Button>
-            <Button tabIndex={-1} selected={value == "bar" ? true : false}  onClick={() => onChange("bar")}>Bar</Button>
-            <Button tabIndex={-1} selected={value == "area" ? true : false}  onClick={() => onChange("area")}>Area</Button>
-            <Button tabIndex={-1} selected={value == "pie" ? true : false}  onClick={() => onChange("pie")}>Pie</Button>
-            <Button tabIndex={-1} selected={value == "scatter" ? true : false}  onClick={() => onChange("scatter")}>Scatter</Button>
-            <Button tabIndex={-1} selected={value == "bubble" ? true : false}  onClick={() => onChange("bubble")}>Bubble</Button>
-            <Button tabIndex={-1} selected={value == "punchcard" ? true : false}  onClick={() => onChange("punchcard")}>Punchcard</Button>
-            <Button tabIndex={-1} selected={value == "link" ? true : false}  onClick={() => onChange("link")}>Link</Button>
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "line" ? true : false}  onClick={() => onChange("line")}>Line</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "column" ? true : false}  onClick={() => onChange("column")}>Column</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "bar" ? true : false}  onClick={() => onChange("bar")}>Bar</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "area" ? true : false}  onClick={() => onChange("area")}>Area</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "pie" ? true : false}  onClick={() => onChange("pie")}>Pie</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "scatter" ? true : false}  onClick={() => onChange("scatter")}>Scatter</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "bubble" ? true : false}  onClick={() => onChange("bubble")}>Bubble</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "punchcard" ? true : false}  onClick={() => onChange("punchcard")}>Punchcard</Button>}
+            {languageId !== 'splunk_spl2' && <Button tabIndex={-1} selected={value == "link" ? true : false}  onClick={() => onChange("link")}>Link</Button>}
         </ButtonGroup>}
         </div>
         <div>

--- a/out/notebooks/renderer/visualization.jsx
+++ b/out/notebooks/renderer/visualization.jsx
@@ -26,7 +26,7 @@ const StyledDiv = styled.div`
 } 
 `
 
-function VizViewer({data, backgroundColor, initialVizType, visualizationOptions}) {
+function VizViewer({data, backgroundColor, initialVizType, visualizationOptions, languageId}) {
 
     let initialType = "events"
  
@@ -100,7 +100,7 @@ function VizViewer({data, backgroundColor, initialVizType, visualizationOptions}
 
     return (
         <div>
-        <VizSelector isCollapsed={initialVizType !== undefined} onChange={handleChangeVizType} value={vizType} style={{"paddingBottom": "10px"}}></VizSelector>
+        <VizSelector isCollapsed={initialVizType !== undefined} onChange={handleChangeVizType} value={vizType} style={{"paddingBottom": "10px"}} languageId={languageId}></VizSelector>
 
         {viz}
         
@@ -115,6 +115,7 @@ export const activate= (_) => ({
 
         const visualizationPreference = _meta.cellMeta?.splunk?.visualizationPreference
         const visualizationOptions = _meta.cellMeta?.splunk?.visualizationOptions
+        const languageId = _meta?.languageId;
 
         console.log(visualizationOptions)
         //element.innerText = "H" + JSON.stringify(data.json())
@@ -127,7 +128,7 @@ export const activate= (_) => ({
         render(
             <SplunkThemeProvider family="prisma" colorScheme={colorScheme} density="compact">
                 <StyledDiv>
-                <VizViewer visualizationOptions={visualizationOptions} initialVizType={visualizationPreference} data={results} backgroundColor={_meta["backgroundColor"]}></VizViewer>
+                <VizViewer visualizationOptions={visualizationOptions} initialVizType={visualizationPreference} data={results} backgroundColor={_meta["backgroundColor"]} languageId={languageId}></VizViewer>
                 </StyledDiv>
         </SplunkThemeProvider>, element)
     },

--- a/out/notebooks/serializers.ts
+++ b/out/notebooks/serializers.ts
@@ -16,7 +16,7 @@ interface RawNotebookCell {
     outputs?: RawCellOutput[];
 }
 
-function transformOutputFromCore(output: vscode.NotebookCellOutput): RawCellOutput {
+export function transformOutputFromCore(output: vscode.NotebookCellOutput): RawCellOutput {
 
     const cellOutput: RawCellOutput = {output_type: "execute_result", data: {}}
 
@@ -27,7 +27,7 @@ function transformOutputFromCore(output: vscode.NotebookCellOutput): RawCellOutp
     return cellOutput
 }
 
-function transformOutputToCore(rawOutput: RawCellOutput): vscode.NotebookCellOutput {
+export function transformOutputToCore(rawOutput: RawCellOutput): vscode.NotebookCellOutput {
     const cellOutput: vscode.NotebookCellOutput = new vscode.NotebookCellOutput([])
 
     for (const [key, value] of Object.entries(rawOutput.data)) {

--- a/out/notebooks/serializers.ts
+++ b/out/notebooks/serializers.ts
@@ -56,7 +56,7 @@ export class SplunkNotebookSerializer implements vscode.NotebookSerializer {
 
         try {
             raw = <RawNotebookCell[]>JSON.parse(contents);
-        } catch {
+        } catch (err) {
             raw = [];
         }
 

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+import {
+    dispatchSpl2Module,
+    getClient,
+} from '../splunk';
+import { SplunkController } from '../controller';
+import { splunkMessagesToOutputItems } from '../utils';
+
+export class Spl2Controller extends SplunkController {
+    constructor() {
+        super('spl2-notebook-controller', 'spl2-notebook', 'SPL2 Note', ['splunk_spl2']);
+        this._controller.executeHandler = this._execute.bind(this);
+    }
+
+    protected _execute(
+        cells: vscode.NotebookCell[],
+        _notebook: vscode.NotebookDocument,
+        _controller: vscode.NotebookController
+    ): void {
+        for (let cell of cells) {
+            if (cell.document.languageId == 'splunk_spl2') {
+                this._doSpl2Execution(cell);
+            }
+        }
+    }
+
+    private async _doSpl2Execution(cell: vscode.NotebookCell): Promise<void> {
+        const execution = super._startExecution(cell);
+
+        const spl2Module = cell.document.getText().trim();
+        const service = getClient();
+    
+        let job;
+        try {
+            job = await dispatchSpl2Module(service, spl2Module);
+            await super._finishExecution(job, cell, execution);
+        } catch (failedResponse) {
+            let outputItems: vscode.NotebookCellOutputItem[] = [];
+            if (!failedResponse.data || !failedResponse.data.messages) {
+                outputItems = [vscode.NotebookCellOutputItem.error(failedResponse)];
+            } else {
+                const messages = failedResponse.data.messages;
+                outputItems = splunkMessagesToOutputItems(messages);
+            }
+
+            execution.replaceOutput([new vscode.NotebookCellOutput(outputItems)]);
+            execution.end(false, Date.now());
+        }
+    }
+}

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -33,7 +33,12 @@ export class Spl2Controller extends SplunkController {
     
         let job;
         try {
-            job = await dispatchSpl2Module(service, spl2Module);
+            job = await dispatchSpl2Module(
+                service,
+                spl2Module,
+                cell?.metadata?.splunk?.earliestTime,
+                cell?.metadata?.splunk?.latestTime,
+            );
             await super._finishExecution(job, cell, execution);
         } catch (failedResponse) {
             let outputItems: vscode.NotebookCellOutputItem[] = [];

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -1,0 +1,25 @@
+import { ExtensionContext, workspace } from 'vscode';
+import {
+    configKeyAcceptedTerms,
+    configKeyJavaPath,
+    configKeyLspVersion,
+    TermsAcceptanceStatus
+} from './installer';
+
+export async function startSpl2ClientAndServer(context: ExtensionContext): Promise<void> {
+    return new Promise((resolve, reject) => {
+        // If the user has already opted-out for good then stop here
+        const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
+        if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
+            reject(
+                `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
+                `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
+            );
+            return;
+        }
+        const javaPath = workspace.getConfiguration().get(configKeyJavaPath);
+        const lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
+        // TODO test for open port and start client and server
+        reject('LSP initialization not implemented');
+    });
+}

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -1,25 +1,354 @@
-import { ExtensionContext, workspace } from 'vscode';
+import * as child_process from 'child_process';
+import { AddressInfo, Socket } from 'net';
+import * as path from 'path';
+import {
+    ExtensionContext,
+    StatusBarItem,
+    workspace,
+} from 'vscode';
+import {
+	LanguageClient,
+	LanguageClientOptions,
+	ServerOptions,
+	State,
+	StreamInfo,
+} from 'vscode-languageclient/node';
+
 import {
     configKeyAcceptedTerms,
     configKeyJavaPath,
     configKeyLspVersion,
-    TermsAcceptanceStatus
+    getLocalLspDir,
+    getLspFilename,
+    TermsAcceptanceStatus,
 } from './installer';
 
-export async function startSpl2ClientAndServer(context: ExtensionContext): Promise<void> {
-    return new Promise((resolve, reject) => {
-        // If the user has already opted-out for good then stop here
-        const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
-        if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
-            reject(
-                `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
-                `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
-            );
-            return;
+interface ModuleItemId {
+	kind: string,
+	path: []
+}
+
+interface ResolveDatasetsParams {
+	user: string,
+	predicate: string,
+	ids: ModuleItemId[]
+}
+
+interface ResolveDataset {
+	owner: string,
+	kind: string,
+	id: string,
+	path: string[],
+	properties: Map<string, object>;
+}
+
+interface LSPLog {
+	timestamp: string,
+	level: string,
+	message: string,
+}
+
+export async function startSpl2ClientAndServer(context: ExtensionContext, progressBar: StatusBarItem, portToAttempt: number, onClose: (nextPort: number) => void): Promise<Spl2ClientServer> {
+    return new Promise(async (resolve, reject) => {
+        try {
+            // If the user has already opted-out for good then stop here
+            const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
+            if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
+                reject(
+                    `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
+                    `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
+                );
+                return;
+            }
+            const javaPath: string = workspace.getConfiguration().get(configKeyJavaPath);
+            if (!javaPath) {
+                reject(
+                    'Error initializing SPL2, please specify a java executable in the Splunk Extension ' +
+                    `Settings under '${configKeyJavaPath}'`
+                );
+                return;
+            }
+            const lspVersion: string = workspace.getConfiguration().get(configKeyLspVersion);
+            if (!lspVersion) {
+                reject(
+                    'Error initializing SPL2, please specify the language server version in the Splunk ' +
+                    `Extension Settings under '${configKeyLspVersion}'`
+                );
+                return;
+            }
+            const lspPath = path.join(getLocalLspDir(context), getLspFilename(lspVersion));
+            
+            const server = new Spl2ClientServer(context, progressBar, javaPath, lspPath, portToAttempt, onClose);
+            await server.initialize();
+            resolve(server);
+        } catch (err) {
+            reject(`Error initializing SPL2, err: ${err}`);
         }
-        const javaPath = workspace.getConfiguration().get(configKeyJavaPath);
-        const lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
-        // TODO test for open port and start client and server
-        reject('LSP initialization not implemented');
     });
 }
+
+export class Spl2ClientServer {
+    context: ExtensionContext;
+    progressBar: StatusBarItem;
+    javaPath: string;
+    lspPath: string;
+    retries: number;
+    restarting: boolean;
+    portToAttempt: number;
+    onClose: (nextPort: number) => void;
+    // Set during initialize():
+    lspPort: number;
+    client: LanguageClient;
+    serverProcess: child_process.ChildProcess;
+    socket: Socket;
+
+    constructor(context: ExtensionContext, progressBar: StatusBarItem, javaPath: string, lspPath: string, portToAttempt: number, onClose: (nextPort: number) => void) {
+        this.context = context;
+        this.progressBar = progressBar;
+        this.javaPath = javaPath;
+        this.lspPath = lspPath;
+        this.retries = 0;
+        this.restarting = false;
+        this.lspPort = -1;
+        this.client = undefined;
+        this.serverProcess = undefined;
+        this.socket = undefined;
+        this.portToAttempt = portToAttempt;
+        this.onClose = onClose;
+    }
+
+    async initialize(): Promise<void> {
+        this.progressBar.text = 'Starting SPL2 Language Server';
+        this.progressBar.show();
+        return new Promise(async (resolve, reject) => {
+            this.lspPort = await getNextAvailablePort(this.portToAttempt, 10)
+                .catch((err) => {
+                    reject(`Unable to find available port for SPL2 language server, err: ${err}`);
+                }) || -1;
+            if (this.lspPort === -1) {
+                reject(`Unable to find available port for SPL2 language server`);
+                return;
+            }
+
+            const serverOptions: ServerOptions = this.setupNewServer();
+        
+            // Options to control the language client
+            const clientOptions: LanguageClientOptions = {
+                documentSelector: [
+                    { language: 'splunk_spl2' },
+                ],
+                initializationOptions: { profile: null },
+            };
+        
+            // Create the language client and start the client.
+            this.client = new LanguageClient(
+                'spl2_client',
+                'SPL2 Language Client',
+                serverOptions,
+                clientOptions
+            );
+        
+            // Attach handlers for catalog item resolution.
+            this.client.onDidChangeState((event) => {
+                if (event.newState === State.Running) {
+                    this.client.onRequest('spl/resolveDatasets', (resolveDatasetsParams: ResolveDatasetsParams): ResolveDataset[] => {
+                        const id = resolveDatasetsParams.ids[0];
+                        // TODO: implement dataset resolution based on existing indexes/datasets within module
+                        return [];
+                    });
+        
+                    this.client.onRequest('spl/resolveModule', (): void => {
+                        // TODO: implement module resolution
+                        return;
+                    });
+                    this.progressBar.text = 'SPL2 Language Server Running';
+                } else if (event.newState === State.Starting) {
+                    this.progressBar.text = 'SPL2 Language Server Starting';
+                } else {
+                    this.progressBar.text = 'SPL2 Language Server Stopped';
+                }
+                this.progressBar.show();
+            });
+        
+            // TODO: spl2/module and spl2/compile are not provided here,
+            // though in the future the compile command can be implemented
+            // to compile to SPL1 which can then be run on any Splunk deployment
+
+            // Start the client. This will also launch the server
+            this.client.start();
+
+            resolve();
+        });
+    }
+    
+    setupNewServer(): ServerOptions {
+        return (): Promise<StreamInfo> => {
+            return new Promise((resolve, reject) => {
+                const javaArgs: string[] = [
+                    '-Xmx2g',
+                    '-jar',
+                    this.lspPath,
+                    '--port',
+                    `${this.lspPort}`,
+                ];
+                this.serverProcess = child_process.spawn(this.javaPath, javaArgs);
+                if (!this.serverProcess || !this.serverProcess.pid) {
+                    reject(`Launching server with ${this.javaPath} ${javaArgs.join(' ')} failed.`);
+                    return;
+                } else {
+                    console.log(`SPL2 Language Server launched with pid: ${this.serverProcess.pid} and listening on port: ${this.lspPort}`);
+                }
+                this.serverProcess.stderr.on('data', stderr => {
+                    console.warn(`[SPL2 Server]: ${stderr}`);
+                    if (stderr.includes('Cannot invoke "java.net.ServerSocket.close()"')) {
+                        if (this.restarting) {
+                            return;
+                        }
+                        // this indicates a socket issue, try next port
+                        console.warn('Connection lost, bumping port and retrying ...');
+                        this.onClose(this.lspPort + 1);
+                    }
+                });
+                this.serverProcess.stdout.on('data', stdout => {
+                    console.log(`[SPL2 Server]: ${stdout}`);
+                    const lspLog: LSPLog = JSON.parse(stdout);
+                    if (lspLog.message.includes('started listening on port')) {
+                        console.log('SPL2 Server is up, starting client...');
+                        // Ready for client
+                        this.socket = new Socket();
+    
+                        this.socket.on('connect', () => {
+                            console.log('Client: connection established with server');
+                            const address:AddressInfo = this.socket.address() as AddressInfo;
+                            console.log(`Client is listening on port ${address.port}`);
+                            // Reset retries after a successful connection
+                            this.retries = 0;
+                            this.restarting = false;
+                            resolve({
+                                writer: this.socket,
+                                reader: this.socket,
+                                // detached: true,
+                            });
+                        });
+    
+                        this.socket.on('close', () => {
+                            if (this.restarting) {
+                                return;
+                            }
+                            this.restarting = true;
+                            console.warn('Connection lost, bumping port and retrying ...');
+                            this.onClose(this.lspPort + 1);
+                        });
+    
+                        this.socket.on('error', (err) => {
+                            if (isNodeError(err) && err.code === 'ECONNRESET') {
+                                // expected when server is killed
+                                console.log('Server connection ended.');
+                                return;
+                            }
+                            console.warn(`error between LSP client/server encountered -> ${err}`);
+                        });
+    
+                        this.socket.connect({
+                            port: this.lspPort,
+                        });
+                    }
+                });
+            });
+        };
+    }
+
+    killServer(): void {
+        console.log(`killServer() called`);
+        if (this.serverProcess && this.serverProcess.pid) {
+            console.log(`Terminating SPL2 Server pid ${this.serverProcess.pid} ...`);
+            this.serverProcess.kill();
+            this.serverProcess = undefined;
+        }
+    }
+  
+    deactivate(): Promise<void> {
+        try {
+            this?.socket.destroy();
+            this.killServer();
+            if (this?.client?.isRunning()) {
+                return this?.client.stop();
+            }
+        } catch (err) {
+            console.warn(`Error deactivating SPL2 client/server, err: ${err}`);
+        }
+        return Promise.resolve();
+    }
+}
+
+/**
+ * Helper to retrieve a socket using the supplied port and incrementing up
+ * to maxAttempts
+ * @param startPort Port to use to start testing with
+ * @param attempts How many attempts to increment port before failing (default: 10)
+ * @returns Promise<Socket> Socket with available port
+ */
+async function getNextAvailablePort(startPort: number, attempts: number): Promise<number> {
+    const maxAttempts = attempts || 10;
+    let attemptPort = startPort;
+    const isSocketInUse = (port: number): Promise<boolean> => {
+        return new Promise((resolve, reject) => {
+            const socket = new Socket();
+            socket.on('connect', () => {
+                // If we connect then this implies the port is in use and listening
+                socket.destroy();
+                console.log(`Port ${port} in use`);
+                resolve(true);
+            });
+    
+            const timeoutMs = 400;
+            socket.setTimeout(timeoutMs); // wait 400 ms before giving up
+            socket.on('timeout', () => {
+                // If we time out, assume port is unoccupied
+                socket.destroy();
+                console.log(`Port ${port} available (timeout)`);
+                resolve(false);
+            });
+  
+            socket.on('error', (err) => {
+                socket.destroy();
+                if (isNodeError(err) && err.code === 'ECONNREFUSED') {
+                    // no connection implies this is not in use
+                    console.log(`Port ${port} available`);
+                    resolve(false);
+                    return;
+                }
+                console.log(`Error connecting to ${port} err -> ${err}`);
+                reject(err); // otherwise we seem to be erroring out for other reasons
+            });
+  
+            console.log(`Trying port ${port} ...`);
+            socket.connect(port);
+      });
+    };
+  
+    let socketInUse = true;
+    while (socketInUse && attemptPort < startPort + maxAttempts) {
+        socketInUse = await isSocketInUse(attemptPort);
+        if (socketInUse) {
+            attemptPort++;
+        }
+    }
+    return new Promise((resolve, reject) => {
+        if (socketInUse) {
+            reject(`Unable to find available port after ${maxAttempts} attempts`);
+            return;
+        }
+        resolve(attemptPort);
+    });
+  }
+  
+  /**
+   * Convenience function to correctly type NodeJS errors that will
+   * have properties such as 'code' as opposed to vanilla JS errors.
+   * @param error Generic error to check for NodeJS.ErrnoException type
+   * @returns Bool if error is a NodeJS error with associated properties
+   */
+  function isNodeError(error: Error): error is NodeJS.ErrnoException {
+    return error instanceof Error;
+  }

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -1,0 +1,506 @@
+import axios from 'axios';
+import * as child_process from 'child_process';
+import { XMLParser} from 'fast-xml-parser';
+import * as fs from 'fs';
+import * as path from 'path';
+import { pipeline } from 'stream';
+import * as tar from 'tar-fs';
+import * as unzipper from 'unzipper';
+import * as util from 'util';
+import { env, ExtensionContext, StatusBarItem, Uri, window, workspace } from 'vscode';
+import * as zlib from 'zlib';
+
+// Keys used to store/retrieve state related to this extension
+export const configKeyAcceptedTerms = 'splunk.spl2.acceptedTerms';
+export const configKeyJavaPath = 'splunk.spl2.javaPath';
+export const configKeyLspVersion = 'splunk.spl2.languageServerVersion';
+
+export const stateKeyLatestLspVersion = 'splunk.spl2.latestLspVersion';
+export const stateKeyLastLspCheck = 'splunk.spl2.lastLspCheck';
+
+// Minimum version of Java needed for SPL2 Language Server
+const minimumMajorJavaVersion = 17;
+
+export enum TermsAcceptanceStatus {
+    DeclinedForever = 'declined (forever)',
+    DeclinedOnce = 'declined (once)',
+    Accepted = 'accepted',
+}
+
+/**
+ * Provide a guided install experience for installing Java and SPL2 Language Server including
+ * accepting Splunk General terms. If compatible Java and Language Server is already installed
+ * this will be a no-op.
+ */
+export async function getMissingSpl2Requirements(context: ExtensionContext, progressBar: StatusBarItem): Promise<boolean> {
+    return new Promise(async (resolve, reject) => {
+        // If the user has already opted-out for good then stop here
+        const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
+        if (termsStatus === TermsAcceptanceStatus.DeclinedForever) {
+            reject(
+                `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
+                `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
+            );
+            return;
+        }
+        // Check for compatible Java version installed already
+        let javaLoc;
+        try {
+            javaLoc = workspace.getConfiguration().get(configKeyJavaPath);
+        } catch (err) {
+            reject(`Error retrieving configuration '${configKeyJavaPath}', err: ${err}`);
+        }
+        // If java hasn't been set up, check $JAVA_HOME before downloading a JDK
+        if (!javaLoc && process.env.JAVA_HOME) {
+            let javaHomeBin = path.join(process.env.JAVA_HOME, 'bin', 'java');
+            if (process.platform === 'win32') {
+                javaHomeBin = `${javaHomeBin}.exe`;
+            }
+            if (isJavaVersionCompatible(javaHomeBin)) {
+                javaLoc = javaHomeBin;
+                try {
+                    workspace.getConfiguration().update(configKeyJavaPath, javaHomeBin, true);
+                } catch (err) {
+                    reject(`Error updating configuration '${configKeyJavaPath}', err: ${err}`);
+                }
+            }
+        }
+
+        // Check workspace for current installed LSP version
+        let lspVersion;
+        try {
+            lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
+        } catch (err) {
+            reject(`Error retrieving configuration '${configKeyLspVersion}', err: ${err}`);
+        }
+        // Setup local storage directory for downloads and installs
+        try {
+            makeLocalStorage(context);
+        } catch (err) {
+            reject(`Error creating local artifact storage for SPL2, err: ${err}`);
+        }
+        
+        let installedLatestLsp = false;
+        if (!lspVersion) {
+            // If we haven't set up a Language Server version prompt use to accept terms
+            // and also confirm install of java if needed
+            try {
+                const accepted = await promptToDownloadLsp(!javaLoc);
+                if (!accepted) {
+                    return;
+                }
+                // Remove any existing LSP artifacts first
+                const localLspDir = getLocalLspDir(context);
+                fs.rmdirSync(localLspDir, { recursive: true });
+                makeLocalStorage(context); // recreate directory
+            
+                await getLatestSpl2Release(context, progressBar);
+                installedLatestLsp = true;
+            } catch (err) {
+                reject(`Error retrieving latest SPL2 release, err: ${err}`);
+            }
+        } else if (!javaLoc) {
+            // Ask user to confirm download, cancel, or opt-out of SPL2 altogether
+            try {
+                const accepted = await promptToDownloadJava();
+                if (!accepted) {
+                    return;
+                }
+            } catch (err) {
+                reject(`Error confirming JDK download, err: ${err}`);
+            }
+        }
+        // We already prompted the user to confirm this download, proceed
+        if (!javaLoc) {
+            // Remove any old artifacts first
+            const localJdkDir = path.join(context.globalStorageUri.fsPath, 'spl2', 'jdk');
+            try {
+                fs.rmdirSync(localJdkDir, { recursive: true });
+                makeLocalStorage(context); // recreate directory
+
+                javaLoc = await installJDK(localJdkDir, progressBar);
+                workspace.getConfiguration().update(configKeyJavaPath, javaLoc, true);
+            } catch (err) {
+                reject(`Error installing JDK for SPL2, err: ${err}`);
+            }
+        }
+        resolve(installedLatestLsp);
+    });
+}
+
+/**
+ * Helper function to run 'java -version' and parse the result to check if it
+ * meets out minimum Java major version
+ * @param javaLoc Location of java executable (e.g. value of $JAVA_HOME) 
+ * @returns true if running `java -version` returns a `version 'X.Y.Z'` where X
+ *          meets out minimum Java major version
+ */
+function isJavaVersionCompatible(javaLoc: string): boolean {
+    try {
+        const javaVerCmd = child_process.spawnSync(javaLoc, ['-version'], { encoding : 'utf8' });
+        if (!javaVerCmd || javaVerCmd.stdout) {
+            return false;
+        }
+        // java -version actually writes to stderr so check for a match there
+        const match = javaVerCmd.stderr.toString().match(/version \"([0-9]+)\.[0-9]+\.[0-9]\"/m);
+        return (match && match.length > 1 && (parseInt(match[1]) >= minimumMajorJavaVersion));
+    } catch (err) {
+        console.warn(`Error checking for java version via '${javaLoc} -version', err: ${err}`);
+    }
+    return false;
+}
+
+/**
+ * Create the local storage directory struture for storing SPL2 artifacts
+ * if they haven't already been created
+ */
+function makeLocalStorage(context: ExtensionContext): void {
+    // We are guaranteed to have read/write access to this directory
+    const localSplunkArtifacts = context.globalStorageUri.fsPath;
+    // Create this directory structure:
+    // .../User/globalStorage/splunk.splunk
+    // └── spl2
+    //     ├── jdk
+    //     └── lsp
+    const spl2Artifacts = getLocalSpl2Dir(context);
+    const jdkArtifacts = getLocalJdkDir(context);
+    const lspArtifacts = getLocalLspDir(context);
+    [localSplunkArtifacts, spl2Artifacts, jdkArtifacts, lspArtifacts].forEach((path) => {
+        if (!fs.existsSync(path)) {
+            fs.mkdirSync(path);
+        }
+    });
+}
+
+function getLocalSpl2Dir(context: ExtensionContext): string {
+    return path.join(context.globalStorageUri.fsPath, 'spl2');
+}
+
+function getLocalJdkDir(context: ExtensionContext): string {
+    return path.join(context.globalStorageUri.fsPath, 'spl2', 'jdk');
+}
+
+function getLocalLspDir(context: ExtensionContext): string {
+    return path.join(context.globalStorageUri.fsPath, 'spl2', 'lsp');
+}
+
+async function promptToDownloadJava(): Promise<boolean> {
+    const promptMessage = (
+        `For SPL2 support Java ${minimumMajorJavaVersion} or later is required.`
+    );
+    const downloadAndInstallChoice = 'Download and Install';
+    const turnOffSPL2Choice = 'Turn off SPL2 support';
+  
+    const popup = window.showInformationMessage(
+        promptMessage,
+        { modal: true },
+        downloadAndInstallChoice,
+        turnOffSPL2Choice,
+    );
+  
+    const userSelection = (await popup) || null;
+    switch(userSelection) {
+        case downloadAndInstallChoice:
+            return true;
+        case turnOffSPL2Choice:
+            console.log('User opted out of SPL2 Langauge Server download, SPL2 support disabled');
+            // Record preference so user is not asked again
+            workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.DeclinedForever, true);
+            return false;
+        default:
+            // Cancel, record no preference
+            return false;
+    }
+}
+
+/**
+ * Helper function to install appropriate JDK to run the SPL2 Language Server
+ * @param installDir Local directory file path to write JDK to
+ */
+async function installJDK(installDir: string, progressBar: StatusBarItem): Promise<string> {
+    let arch = '';
+    let os = '';
+    let ext = 'tar.gz';
+    // Determine architecture
+    switch(process.arch) {
+        case 'x64':
+            arch = process.arch;
+            break;
+        case 'arm64':
+            arch = 'aarch64';
+            break;
+        default:
+            throw new Error(
+                `No JDK found for architecture: '${process.arch}'. To continue ` +
+                `install a Java ${minimumMajorJavaVersion} or later JDK and configure ` +
+                `the location in the Splunk Extension Settings under '${configKeyJavaPath}'.`
+            );
+    }
+    // Determine OS/extension
+    switch(process.platform) {
+        case 'darwin':
+            os = 'macos';
+            break;
+        case 'win32':
+            os = 'windows';
+            ext = 'zip';
+            break;
+        default:
+            os = 'linux';
+    }
+    
+    const filename = `amazon-corretto-${minimumMajorJavaVersion}-${arch}-${os}-jdk.${ext}`;
+    const url = `https://corretto.aws/downloads/latest/${filename}`;
+    
+    // Download to installDir
+    const downloadedArchive = path.join(installDir, filename);
+    let compressedSize = 0;
+    try {
+        compressedSize = await downloadWithProgress(url, downloadedArchive, progressBar, 'Downloading JDK');
+    } catch (err) {
+        throw new Error(`Error downloading JDK: ${err}`);
+    }
+
+    // Extract JDK and return path to java executable
+    let binJarPath;
+
+    progressBar.show();
+    try {
+        if (ext === 'zip') {
+            binJarPath = await extractZipWithProgress(downloadedArchive, installDir, compressedSize, progressBar, 'Unzipping JDK');
+        } else { // tar.gz
+            binJarPath = await extractTgzWithProgress(downloadedArchive, installDir, compressedSize, progressBar, 'Extracting JDK');
+        }
+    } catch (err) {
+        throw new Error(`Error extracting JDK: ${err}`);
+    } finally {
+        progressBar.hide();
+    }
+    if (!binJarPath) {
+        throw new Error(`Error finding path to java executable within extracted JDK`);
+    }
+    return binJarPath;
+}
+
+/**
+ * Helper function to download a file, updating a progress bar while downloading, and returning
+ * a Promise containing the total size of the download.
+ * @param url URL of artifact to download
+ * @param destinationPath Local path to download to
+ * @param progressBar To update download progress
+ * @param progressBarText Text describing what's being downloaded to precede download %
+ * @returns 
+ */
+async function downloadWithProgress(
+    url: string,
+    destinationPath: string,
+    progressBar: StatusBarItem,
+    progressBarText: string,
+): Promise<number> {
+    const fileWriter = fs.createWriteStream(destinationPath);
+
+    return new Promise(async (resolve, reject) => {
+        const { data, headers } = await axios({
+            url,
+            method: 'GET',
+            responseType: 'stream',
+            transformRequest: (data, headers) => {
+                // Override defaults set elsewhere for splunkd communication
+                delete headers.common['Authorization'];
+                delete headers.common['Accept'];
+                return data;
+              },
+        });
+        const totalSize = parseInt(headers['content-length']);
+        let totalDownloaded = 0;
+        let nextUpdate = 1;
+        let error;
+        progressBar.show();
+        data.on('data', (chunk) => {
+            totalDownloaded += chunk.length;
+            let pct = Math.floor(totalDownloaded * 100 / totalSize);
+            if (pct === nextUpdate) {
+                progressBar.text = `${progressBarText} ${pct}%`;
+                nextUpdate++;
+            }
+        });
+        fileWriter.on('error', (err) => {
+            error = err;
+            fileWriter.close();
+            reject(err);
+        });
+        fileWriter.on('close', () => {
+            if (!error) {
+                progressBar.hide();
+                resolve(totalSize);
+            }
+        });
+        data.pipe(fileWriter);
+    });
+}
+
+async function extractZipWithProgress(
+    zipfilePath:string,
+    extractPath: string,
+    compressedSize: number,
+    progressBar: StatusBarItem,
+    progressBarText: string,
+): Promise<string> {
+    // Create read and unzip streams and listen for individual entry to find bin\java.exe
+    let binJavaPath;
+    let readCompressedSize = 0;
+    let nextUpdate = 1;
+
+    const pipe = util.promisify(pipeline);
+    const readStream = fs.createReadStream(zipfilePath);
+    const unzipStream = unzipper.Extract({ path: extractPath });
+    unzipStream._writable.on('entry', entry => {
+        if (entry.path.endsWith(path.join('bin', 'java.exe'))) {
+            binJavaPath = path.join(extractPath, entry.path);
+        }
+        readCompressedSize += entry.vars.compressedSize;
+        let pct = Math.floor(readCompressedSize * 100 / compressedSize);
+        if (pct === nextUpdate) {
+            progressBar.text = `${progressBarText} ${pct}%`;
+            nextUpdate++;
+        }
+        entry.autodrain();
+    });
+    await pipe(
+        readStream,
+        unzipStream,
+    );
+    return binJavaPath;
+}
+
+async function extractTgzWithProgress(
+        tgzPath:string,
+        extractPath: string,
+        compressedSize: number,
+        progressBar: StatusBarItem,
+        progressBarText: string,
+    ): Promise<string> {
+    // Create read and unzip streams and listen for individual entry to find bin\java.exe
+    let binJavaPath;
+    let readCompressedSize = 0;
+    let nextUpdate = 1;
+
+    const pipe = util.promisify(pipeline);
+    
+    await pipe(
+        fs.createReadStream(tgzPath).on('data', (chunk) => {
+            readCompressedSize += chunk.length;
+            let pct = Math.floor(readCompressedSize * 100 / compressedSize);
+            if (pct === nextUpdate) {
+                progressBar.text = `${progressBarText} ${pct}%`;
+                nextUpdate++;
+            }
+        }),
+        zlib.createGunzip(),
+        tar.extract(extractPath, {
+            map: (header) => {
+                if (header.name.endsWith(path.join('bin', 'java'))) {
+                    binJavaPath = path.join(extractPath, header.name);
+                }
+                return header;
+            }
+        }),
+    );
+    return binJavaPath;
+}
+
+async function promptToDownloadLsp(alsoInstallJava: boolean): Promise<boolean> {
+    const promptMessage = (
+        'For SPL2 support with this extension a download of the SPL2 Language ' +
+        'Server subject to the Splunk General Terms ' +
+        (
+            alsoInstallJava ?
+                `and of Java ${minimumMajorJavaVersion} are required.` :
+                'is required.'
+        )
+    );
+    const agreeAndContinueChoice = 'Agree and Continue';
+    const viewTermsChoice = 'View Splunk General Terms';
+    const turnOffSPL2Choice = 'Turn off SPL2 support';
+
+    const popup = window.showInformationMessage(
+        promptMessage,
+        { modal: true },
+        agreeAndContinueChoice,
+        viewTermsChoice,
+        turnOffSPL2Choice,
+    );
+    
+    const userSelection = (await popup) || null;
+    switch(userSelection) {
+        case agreeAndContinueChoice:
+            // Record preference so user is not asked again
+            workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.Accepted, true);
+            return true;
+        case viewTermsChoice:
+            console.log('Viewing Splunk General Terms in browser...');
+            env.openExternal(Uri.parse('https://www.splunk.com/en_us/legal/splunk-general-terms.html'));
+            return await promptToDownloadLsp(alsoInstallJava);
+        case turnOffSPL2Choice:
+            console.log('User opted out of SPL2 Langauge Server download, SPL2 support disabled');
+            // Record preference so user is not asked again
+            workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.DeclinedForever, true);
+            return false;
+        default:
+            // Cancel
+            return false;
+    }
+}
+
+/**
+ * Checks if the installed SPL2 Language Server version is the latest and prompt for
+ * upgrade if not, or automatically upgrade if user has that setting enabled.
+ */
+export async function getLatestSpl2Release(context: ExtensionContext, progressBar: StatusBarItem): Promise<void> {
+    return new Promise(async (resolve, reject) => {
+        const lspArtifactPath = path.join(context.globalStorageUri.fsPath, 'lsp');
+        // TODO: Remove this hardcoded version/update time and check for updates
+        let lspVersion: string = '2.0.362'; // context.globalState.get(stateKeyLatestLspVersion) || "";
+        const lastUpdateMs: number = Date.now(); // context.globalState.get(stateKeyLastLspCheck) || 0;
+        // Check for new version of SPL2 Language Server if longer than 24 hours
+        if (Date.now() - lastUpdateMs > 24 * 60 * 60 * 1000) {
+            const metaPath = path.join(lspArtifactPath, 'maven-metadata.xml');
+            try {
+                await downloadWithProgress(
+                    'https://splunk.jfrog.io/splunk/maven-splunk-release/spl2/com/splunk/spl/spl-lang-server-sockets/maven-metadata.xml',
+                    metaPath,
+                    progressBar,
+                    'Checking for SPL2 updates',
+                );
+                const parser = new XMLParser();
+                const metadata = fs.readFileSync(metaPath);
+                const metaParsed = parser.parse(metadata);
+                lspVersion = metaParsed?.metadata?.versioning?.release;
+            } catch (err) {
+                console.warn(`Error retrieving latest SPL2 version, err: ${err}`);
+            }
+        }
+        const lspFilename = `spl-lang-server-sockets-${lspVersion}-all.jar`;
+        const localLspPath = path.join(getLocalLspDir(context), lspFilename);
+        // Check if local file exists before downloading
+        if (!fs.existsSync(localLspPath)) {
+            try {
+                await downloadWithProgress(
+                    `https://splunk.jfrog.io/splunk/maven-splunk/spl2/com/splunk/spl/spl-lang-server-sockets/${lspVersion}/${lspFilename}`,
+                    localLspPath,
+                    progressBar,
+                    'Downloading SPL2 Language Server',
+                );
+            } catch (err) {
+                reject(`Error downloading SPL2 Language Server, err: ${err}`);
+            }
+        }
+        // Update this setting to indicate that this version is ready-to-use
+        try {
+            workspace.getConfiguration().update(configKeyLspVersion, lspVersion, true);
+        } catch (err) {
+            reject(`Error updating configuration '${configKeyLspVersion}', err: ${err}`);
+        }
+        resolve();
+    });
+}

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -32,7 +32,7 @@ export enum TermsAcceptanceStatus {
  * accepting Splunk General terms. If compatible Java and Language Server is already installed
  * this will be a no-op.
  */
-export async function getMissingSpl2Requirements(context: ExtensionContext, progressBar: StatusBarItem): Promise<boolean> {
+export async function installMissingSpl2Requirements(context: ExtensionContext, progressBar: StatusBarItem): Promise<boolean> {
     return new Promise(async (resolve, reject) => {
         // If the user has already opted-out for good then stop here
         const termsStatus: TermsAcceptanceStatus = workspace.getConfiguration().get(configKeyAcceptedTerms);
@@ -41,7 +41,7 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
                 `User opted out of SPL2. To reset this adjust the '${configKeyAcceptedTerms}' ` +
                 `setting to = '${TermsAcceptanceStatus.DeclinedOnce}' in the Splunk Extension Settings.`
             );
-            return;
+            return Promise.resolve();
         }
         // Check for compatible Java version installed already
         let javaLoc;
@@ -72,6 +72,10 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
             lspVersion = workspace.getConfiguration().get(configKeyLspVersion);
         } catch (err) {
             reject(`Error retrieving configuration '${configKeyLspVersion}', err: ${err}`);
+        }
+        if (javaLoc && lspVersion) {
+            // Already set up, no need to continue
+            resolve(false);
         }
         // Setup local storage directory for downloads and installs
         try {
@@ -104,7 +108,7 @@ export async function getMissingSpl2Requirements(context: ExtensionContext, prog
             try {
                 const accepted = await promptToDownloadJava();
                 if (!accepted) {
-                    return;
+                    return Promise.resolve();
                 }
             } catch (err) {
                 reject(`Error confirming JDK download, err: ${err}`);
@@ -180,8 +184,12 @@ function getLocalJdkDir(context: ExtensionContext): string {
     return path.join(context.globalStorageUri.fsPath, 'spl2', 'jdk');
 }
 
-function getLocalLspDir(context: ExtensionContext): string {
+export function getLocalLspDir(context: ExtensionContext): string {
     return path.join(context.globalStorageUri.fsPath, 'spl2', 'lsp');
+}
+
+export function getLspFilename(lspVersion: string): string {
+    return `spl-lang-server-sockets-${lspVersion}-all.jar`;
 }
 
 async function promptToDownloadJava(): Promise<boolean> {
@@ -201,15 +209,15 @@ async function promptToDownloadJava(): Promise<boolean> {
     const userSelection = (await popup) || null;
     switch(userSelection) {
         case downloadAndInstallChoice:
-            return true;
+            return Promise.resolve(true);
         case turnOffSPL2Choice:
             console.log('User opted out of SPL2 Langauge Server download, SPL2 support disabled');
             // Record preference so user is not asked again
             workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.DeclinedForever, true);
-            return false;
+            return Promise.resolve(false);
         default:
             // Cancel, record no preference
-            return false;
+            return Promise.resolve(false);
     }
 }
 
@@ -262,24 +270,42 @@ async function installJDK(installDir: string, progressBar: StatusBarItem): Promi
     }
 
     // Extract JDK and return path to java executable
-    let binJarPath;
+    let binJavaPath;
 
     progressBar.show();
     try {
         if (ext === 'zip') {
-            binJarPath = await extractZipWithProgress(downloadedArchive, installDir, compressedSize, progressBar, 'Unzipping JDK');
+            binJavaPath = await extractZipWithProgress(downloadedArchive, installDir, compressedSize, progressBar, 'Unzipping JDK');
         } else { // tar.gz
-            binJarPath = await extractTgzWithProgress(downloadedArchive, installDir, compressedSize, progressBar, 'Extracting JDK');
+            binJavaPath = await extractTgzWithProgress(downloadedArchive, installDir, compressedSize, progressBar, 'Extracting JDK');
+        }
+        if (!binJavaPath) {
+            // If not found during unpacking, search for bin/java[.exe] and check that file
+            let pathSuffix = path.join('bin', 'java');
+            if (true || process.platform === 'win32') {
+                pathSuffix = `${pathSuffix}.exe`;
+            }
+            const matches = getFilesInDirectory(installDir)
+                .filter((file) => {
+                    return file.endsWith(pathSuffix);
+                });
+            if (matches.length === 0) {
+                throw new Error(`No ${pathSuffix} found within extracted JDK in ${installDir}`);
+            }
+            binJavaPath = matches[0];
+            if (!isJavaVersionCompatible(binJavaPath)) {
+                throw new Error(`Java executable found at ${binJavaPath} has -version not matching ${minimumMajorJavaVersion}+`);
+            }
         }
     } catch (err) {
         throw new Error(`Error extracting JDK: ${err}`);
     } finally {
         progressBar.hide();
     }
-    if (!binJarPath) {
+    if (!binJavaPath) {
         throw new Error(`Error finding path to java executable within extracted JDK`);
     }
-    return binJarPath;
+    return Promise.resolve(binJavaPath);
 }
 
 /**
@@ -370,7 +396,7 @@ async function extractZipWithProgress(
         readStream,
         unzipStream,
     );
-    return binJavaPath;
+    return Promise.resolve(binJavaPath);
 }
 
 async function extractTgzWithProgress(
@@ -402,11 +428,11 @@ async function extractTgzWithProgress(
                 if (header.name.endsWith(path.join('bin', 'java'))) {
                     binJavaPath = path.join(extractPath, header.name);
                 }
-                return header;
+                return Promise.resolve(header);
             }
         }),
     );
-    return binJavaPath;
+    return Promise.resolve(binJavaPath);
 }
 
 async function promptToDownloadLsp(alsoInstallJava: boolean): Promise<boolean> {
@@ -436,19 +462,19 @@ async function promptToDownloadLsp(alsoInstallJava: boolean): Promise<boolean> {
         case agreeAndContinueChoice:
             // Record preference so user is not asked again
             workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.Accepted, true);
-            return true;
+            return Promise.resolve(true);
         case viewTermsChoice:
             console.log('Viewing Splunk General Terms in browser...');
             env.openExternal(Uri.parse('https://www.splunk.com/en_us/legal/splunk-general-terms.html'));
-            return await promptToDownloadLsp(alsoInstallJava);
+            return promptToDownloadLsp(alsoInstallJava);
         case turnOffSPL2Choice:
             console.log('User opted out of SPL2 Langauge Server download, SPL2 support disabled');
             // Record preference so user is not asked again
             workspace.getConfiguration().update(configKeyAcceptedTerms, TermsAcceptanceStatus.DeclinedForever, true);
-            return false;
+            return Promise.resolve(false);
         default:
             // Cancel
-            return false;
+            return Promise.resolve(false);
     }
 }
 
@@ -480,7 +506,7 @@ export async function getLatestSpl2Release(context: ExtensionContext, progressBa
                 console.warn(`Error retrieving latest SPL2 version, err: ${err}`);
             }
         }
-        const lspFilename = `spl-lang-server-sockets-${lspVersion}-all.jar`;
+        const lspFilename = getLspFilename(lspVersion);
         const localLspPath = path.join(getLocalLspDir(context), lspFilename);
         // Check if local file exists before downloading
         if (!fs.existsSync(localLspPath)) {
@@ -504,3 +530,21 @@ export async function getLatestSpl2Release(context: ExtensionContext, progressBa
         resolve();
     });
 }
+
+/**
+ * Helper function to get all files nested under a given directory
+ * and subdirectories.
+ */
+function getFilesInDirectory(directory: string): string[] {
+    const files: string[] = [];
+    const filesInDirectory = fs.readdirSync(directory);
+    for (const file of filesInDirectory) {
+        const fullPath = path.join(directory, file);
+        if (fs.statSync(fullPath).isDirectory()) {
+            files.push(...getFilesInDirectory(fullPath));
+        } else {
+            files.push(fullPath);
+        }
+    }
+    return files;
+};

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -36,7 +36,7 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
 
         try {
             raw = <Spl2ModulesJson>JSON.parse(contents);
-        } catch {
+        } catch (err) {
             raw = <Spl2ModulesJson>{
                 modules: [],
                 app: "apps.search",

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -1,0 +1,82 @@
+import { TextDecoder, TextEncoder } from 'util';
+import {
+    RawCellOutput,
+    transformOutputFromCore,
+    transformOutputToCore,
+} from '../serializers';
+import * as vscode from 'vscode';
+
+// Hardcode a few values that will never change for SPL2 notebooks
+const spl2CellKind = vscode.NotebookCellKind.Code;
+const spl2CellLanguage = 'splunk_spl2';
+
+interface Spl2ModulesJson {
+    modules: Spl2ModuleCell[],
+    app: string, // hardcoded to apps.search for now
+}
+
+interface Spl2ModuleCell {
+    name: string; // hardcoded to module1, module2, etc for now
+    namespace: string; // hardcoded to "" for now
+    definition: string; // SPL2 statements
+    _vscode: {
+        metadata: { [key: string]: any };
+        outputs?: RawCellOutput[];
+    };
+}
+
+export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
+    async deserializeNotebook(
+        content: Uint8Array,
+        token: vscode.CancellationToken
+    ): Promise<vscode.NotebookData> {
+        var contents = new TextDecoder().decode(content);
+
+        let raw: Spl2ModulesJson;
+
+        try {
+            raw = <Spl2ModulesJson>JSON.parse(contents);
+        } catch {
+            raw = <Spl2ModulesJson>{
+                modules: [],
+                app: "apps.search",
+            };
+        }
+
+        const cells = raw.modules.map((module) => {
+            let newCell = new vscode.NotebookCellData(spl2CellKind, module.definition, spl2CellLanguage);
+
+            newCell.metadata = module._vscode.metadata || {};
+            newCell.outputs = module._vscode.outputs.map(output => transformOutputToCore(output))
+
+            return newCell;
+        });
+
+        return new vscode.NotebookData(cells);
+    }
+
+    async serializeNotebook(
+        data: vscode.NotebookData,
+        token: vscode.CancellationToken
+    ): Promise<Uint8Array> {
+        let contents: Spl2ModulesJson = <Spl2ModulesJson>{
+            modules: [],
+            app: "apps.search",
+        };
+
+        let indx = 1;
+        for (const cell of data.cells) {
+            contents.modules.push(<Spl2ModuleCell>{
+                name: `module${indx++}`,
+                namespace: "",
+                definition: cell.value,
+                _vscode: {
+                    metadata: cell.metadata,
+                    outputs: cell.outputs.map((output) => transformOutputFromCore(output)),
+                },
+            });
+        }
+
+        return new TextEncoder().encode(JSON.stringify(contents, null, 2));
+    }
+}

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -56,7 +56,7 @@ export function createSearchJob(jobs, query, options) {
     });
 }
 
-export function dispatchSpl2Module(service: any, spl2Module: string) {
+export function dispatchSpl2Module(service: any, spl2Module: string, earliest: string, latest: string) {
     // Get last statement assignment '$my_statement = ...' -> 'my_statement' 
     const statementMatches = [...spl2Module.matchAll(/\$([a-zA-Z0-9_]+)[\s]*=/gm)];
     if (!statementMatches
@@ -68,6 +68,20 @@ export function dispatchSpl2Module(service: any, spl2Module: string) {
         );
     }
     const statementIdentifier = statementMatches[statementMatches.length - 1][1];
+    const params = {
+        'timezone': 'Etc/UTC',
+        'collectFieldSummary': true,
+        'collectEventSummary': false,
+        'collectTimeBuckets': false,
+        'output_mode': 'json_cols',
+        'status_buckets': 300,
+    };
+    if (earliest !== undefined) {
+        params['earliest'] = earliest;
+    }
+    if (latest !== undefined) {
+        params['latest'] = latest;
+    }
 
     // The Splunk SDK for Javascript doesn't currently support the spl2-module-dispatch endpoint
     // nor does it support sending requests in JSON format (only receiving responses), so
@@ -79,14 +93,7 @@ export function dispatchSpl2Module(service: any, spl2Module: string) {
             'module': spl2Module,
             'namespace': '',
             'queryParameters': {
-                [statementIdentifier]: {
-                    'timezone': 'Etc/UTC',
-                    'collectFieldSummary': true,
-                    'collectEventSummary': false,
-                    'collectTimeBuckets': false,
-                    'output_mode': 'json_cols',
-                    'status_buckets': 300,
-                }
+                [statementIdentifier]: params
             }
         },
         {

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -1,5 +1,7 @@
 import * as splunk from 'splunk-sdk';
-import * as vscode from 'vscode'
+import * as needle from 'needle'; // transitive dependency of splunk-sdk
+import * as vscode from 'vscode';
+import { SplunkMessage } from './utils';
 
 export function getClient() {
     const config = vscode.workspace.getConfiguration();
@@ -20,7 +22,7 @@ export function getClient() {
         authorization: 'Bearer',
     });
 
-    return service
+    return service;
 }
 
 export function splunkLogin(service) {
@@ -29,42 +31,133 @@ export function splunkLogin(service) {
         
         service.login(function(err, wasSuccessful) {
             if (err !== null || !wasSuccessful) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(null)
+                resolve(null);
             }
-        })
+        });
 
-    })
+    });
 
 
 }
 
 
 export function createSearchJob(jobs, query, options) {
-
     return new Promise(function(resolve, reject) {
         jobs.create(query, options, function(err, data) {
             if (err !== null) {
                 reject(err);
             } else {
-                resolve(data)
+                resolve(data);
             }
-        })
+        });
 
-    })
+    });
+}
+
+export function dispatchSpl2Module(service: any, spl2Module: string) {
+    // Get last statement assignment '$my_statement = ...' -> 'my_statement' 
+    const statementMatches = [...spl2Module.matchAll(/\$([a-zA-Z0-9_]+)[\s]*=/gm)];
+    if (!statementMatches
+        || statementMatches.length < 1
+        || statementMatches[statementMatches.length - 1].length < 2) {
+        throw new Error(
+            'No statements found in SPL2. Please assign at least one statement name ' +
+            'using "$". For example: `$my_statement = from _internal`'
+        );
+    }
+    const statementIdentifier = statementMatches[statementMatches.length - 1][1];
+
+    // The Splunk SDK for Javascript doesn't currently support the spl2-module-dispatch endpoint
+    // nor does it support sending requests in JSON format (only receiving responses), so
+    // for now use the underlying needle library that the SDK uses for requests/responses
+    return needle(
+        'POST',
+        `${service.prefix}/services/search/spl2-module-dispatch`,
+        {
+            'module': spl2Module,
+            'namespace': '',
+            'queryParameters': {
+                [statementIdentifier]: {
+                    'timezone': 'Etc/UTC',
+                    'collectFieldSummary': true,
+                    'collectEventSummary': false,
+                    'collectTimeBuckets': false,
+                    'output_mode': 'json_cols',
+                    'status_buckets': 300,
+                }
+            }
+        },
+        {
+            'headers': {
+                'Authorization': `Bearer ${service.sessionKey}`,
+                'Content-Type': 'application/json',
+            },
+            'followAllRedirects': true,
+            'timeout': 0,
+            'strictSSL': false,
+            'rejectUnauthorized' : false,
+        })
+        .then((response) => {
+            const data = response.body;
+            if (!Array.prototype.isPrototypeOf(data) || data.length < 1) {
+                // Response is not in expected successful format, let's handle a
+                // few different error cases and raise as expected messages format
+                let messages:SplunkMessage[] = [];
+                if (Object.prototype.isPrototypeOf(data)) {
+                    if (data.name === 'response'
+                        && Array.prototype.isPrototypeOf(data.children)) {
+                        // Reformat messages for errors such as unauthorized
+                        messages = data.children
+                            .filter((child) => child.name === 'messages')
+                            .flatMap((msgs) => msgs.children)
+                            .map((msg) => new Object({
+                                    'type': msg?.attributes?.type,
+                                    'code': msg.name,
+                                    'text': msg.value,
+                            }));
+                    } else if (data.code !== undefined && data.message !== undefined) {
+                        // Reformat if returns a `code` and `message for errors such
+                        // as invalid request body format
+                        messages = [{
+                            'type': 'error',
+                            'code': data.code,
+                            'text': data.message,
+                        }];
+                    }
+                }
+                // If we still haven't handled this unsuccessful response then simply
+                // output the body as an error message
+                if (messages.length === 0) {
+                    messages = [{
+                        'type': 'error',
+                        'code': '',
+                        'text': `Error dispatching SPL2: ${JSON.stringify(data)}`,
+                    }];
+                }
+                throw new Object({
+                    'data': {
+                        'messages': messages,
+                    },
+                }); 
+            }
+            // This is in the expected successful response format
+            const sid = data[0]['sid'];
+            return getSearchJobBySid(service, sid);
+        });
 }
 
 export function getSearchJobBySid(service, sid) {
     return new Promise(function(resolve, reject) {
         service.getJob(sid, function(err, data) {
             if (err != null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(data)
+                resolve(data);
             }
-        })
-    })
+        });
+    });
 }
 
 
@@ -72,52 +165,52 @@ export function getSearchJob(job) {
     return new Promise(function(resolve, reject) {
         job.fetch(function(err, job) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(job)
+                resolve(job);
             }
-        })
+        });
 
-    })
+    });
 }
 
 export function getJobSearchLog(job) {
     return new Promise(function(resolve, reject) {
         job.searchlog(function(err, log) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(log)
+                resolve(log);
             }
-        })
+        });
 
-    })
+    });
 }
 
 export function getSearchJobResults(job) {
     return new Promise(function(resolve, reject) {
         job.get("results", {"output_mode": "json_cols"},function(err, results) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(results)
+                resolve(results);
             }
-        })
+        });
 
-    })
+    });
 }
 
 export function cancelSearchJob(job) {
     return new Promise(function(resolve, reject) {
         job.cancel(function(err, results) {
             if (err !== null) {
-                reject(err)
+                reject(err);
             } else {
-                resolve(results)
+                resolve(results);
             }
 
-        })
-    })
+        });
+    });
 }
 
 export function wait(ms = 1000) {

--- a/out/notebooks/utils.ts
+++ b/out/notebooks/utils.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-interface SplunkMessage {
+export interface SplunkMessage {
     type: string,
     code: string,
     text: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "splunk",
-    "version": "0.2.11-beta1",
+    "version": "0.2.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "splunk",
-            "version": "0.2.11-beta1",
+            "version": "0.2.10",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-env": "^7.20.2",
@@ -18,6 +18,7 @@
                 "@types/vscode-notebook-renderer": "^1.72.0",
                 "axios": ">=0.27.2",
                 "babel-loader": "^9.1.0",
+                "extract-zip": "^2.0.1",
                 "fast-xml-parser": "^4.2.4",
                 "react": "^16",
                 "react-dom": "^16.14.0",
@@ -26,7 +27,6 @@
                 "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
                 "typescript": "^4.2.2",
-                "unzipper": "^0.10.14",
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
@@ -3510,6 +3510,15 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "peer": true
         },
+        "node_modules/@types/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+            "optional": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@ungap/promise-all-settled": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -4335,6 +4344,7 @@
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -4351,6 +4361,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -4394,7 +4405,8 @@
         "node_modules/bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -4481,6 +4493,14 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4490,6 +4510,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
             "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -4498,6 +4519,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
             "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.2.0"
             }
@@ -4629,6 +4651,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
             },
@@ -5553,6 +5576,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
@@ -6203,6 +6227,39 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "dependencies": {
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "bin": {
+                "extract-zip": "cli.js"
+            },
+            "engines": {
+                "node": ">= 10.17.0"
+            },
+            "optionalDependencies": {
+                "@types/yauzl": "^2.9.1"
+            }
+        },
+        "node_modules/extract-zip/node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6293,6 +6350,14 @@
             "peer": true,
             "dependencies": {
                 "bser": "2.1.1"
+            }
+        },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "dependencies": {
+                "pend": "~1.2.0"
             }
         },
         "node_modules/file-entry-cache": {
@@ -6522,6 +6587,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -6536,6 +6602,7 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -7743,7 +7810,8 @@
         "node_modules/listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -9709,6 +9777,11 @@
                 "pbf": "bin/pbf"
             }
         },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -11090,7 +11163,8 @@
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -12002,6 +12076,7 @@
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -12228,6 +12303,7 @@
             "version": "0.10.14",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
             "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+            "dev": true,
             "dependencies": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -12809,6 +12885,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "node_modules/yocto-queue": {
@@ -15396,6 +15481,15 @@
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "peer": true
         },
+        "@types/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+            "optional": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@ungap/promise-all-settled": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -16043,7 +16137,8 @@
         "big-integer": {
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+            "dev": true
         },
         "bignumber.js": {
             "version": "8.1.1",
@@ -16054,6 +16149,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+            "dev": true,
             "requires": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -16090,7 +16186,8 @@
         "bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -16144,6 +16241,11 @@
                 "ieee754": "^1.1.13"
             }
         },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
+        },
         "buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -16152,12 +16254,14 @@
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "dev": true
         },
         "buffers": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+            "dev": true
         },
         "bytes": {
             "version": "3.0.0",
@@ -16248,6 +16352,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+            "dev": true,
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
             }
@@ -16996,6 +17101,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
             }
@@ -17501,6 +17607,27 @@
                 }
             }
         },
+        "extract-zip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+            "requires": {
+                "@types/yauzl": "^2.9.1",
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
+                "yauzl": "^2.10.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
+            }
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -17571,6 +17698,14 @@
             "peer": true,
             "requires": {
                 "bser": "2.1.1"
+            }
+        },
+        "fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "requires": {
+                "pend": "~1.2.0"
             }
         },
         "file-entry-cache": {
@@ -17736,6 +17871,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -17747,6 +17883,7 @@
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -18689,7 +18826,8 @@
         "listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+            "dev": true
         },
         "loader-runner": {
             "version": "4.3.0",
@@ -20255,6 +20393,11 @@
                 "resolve-protobuf-schema": "^2.1.0"
             }
         },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+        },
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -21335,7 +21478,8 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
         },
         "setprototypeof": {
             "version": "1.2.0",
@@ -22064,7 +22208,8 @@
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+            "dev": true
         },
         "ts-loader": {
             "version": "9.4.2",
@@ -22227,6 +22372,7 @@
             "version": "0.10.14",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
             "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+            "dev": true,
             "requires": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -22670,6 +22816,15 @@
                 "decamelize": "^4.0.0",
                 "flat": "^5.0.2",
                 "is-plain-obj": "^2.1.0"
+            }
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "splunk",
-    "version": "0.2.10",
+    "version": "0.2.11-beta1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "splunk",
-            "version": "0.2.10",
+            "version": "0.2.11-beta1",
             "license": "MIT",
             "dependencies": {
                 "@babel/preset-env": "^7.20.2",
@@ -26,7 +26,8 @@
                 "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
                 "typescript": "^4.2.2",
-                "unzipper": "^0.10.14"
+                "unzipper": "^0.10.14",
+                "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.1",
@@ -12362,6 +12363,60 @@
             "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
             "peer": true
         },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "dependencies": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "engines": {
+                "vscode": "^1.67.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+        },
         "node_modules/vscode-test": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -22265,6 +22320,53 @@
             "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
             "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
             "peer": true
+        },
+        "vscode-jsonrpc": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+        },
+        "vscode-languageclient": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+            "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+            "requires": {
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.3"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+            "requires": {
+                "vscode-jsonrpc": "8.1.0",
+                "vscode-languageserver-types": "3.17.3"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
         },
         "vscode-test": {
             "version": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,15 @@
                 "@types/vscode-notebook-renderer": "^1.72.0",
                 "axios": ">=0.27.2",
                 "babel-loader": "^9.1.0",
+                "fast-xml-parser": "^4.2.4",
                 "react": "^16",
                 "react-dom": "^16.14.0",
                 "splunk-sdk": "^1.12.1",
                 "styled-components": "5",
+                "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
-                "typescript": "^4.2.2"
+                "typescript": "^4.2.2",
+                "unzipper": "^0.10.14"
             },
             "devDependencies": {
                 "@types/glob": "^7.1.1",
@@ -4320,8 +4323,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "peer": true
+            ]
         },
         "node_modules/batch-processor": {
             "version": "1.0.0",
@@ -4332,7 +4334,6 @@
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
             "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.6"
             }
@@ -4349,7 +4350,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -4371,7 +4371,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "peer": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -4382,7 +4381,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -4395,8 +4393,7 @@
         "node_modules/bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -4478,7 +4475,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -4493,7 +4489,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
             "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -4502,7 +4497,6 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
             "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.2.0"
             }
@@ -4634,7 +4628,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
             },
@@ -4704,6 +4697,11 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "node_modules/chroma-js": {
             "version": "2.4.2",
@@ -5554,7 +5552,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
@@ -5612,7 +5609,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "peer": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -6250,6 +6246,27 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-xml-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -6463,6 +6480,11 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
         "node_modules/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -6499,7 +6521,6 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -6514,7 +6535,6 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -7722,8 +7742,7 @@
         "node_modules/listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
@@ -8934,6 +8953,11 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "node_modules/mocha": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
@@ -9917,7 +9941,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "peer": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -11066,8 +11089,7 @@
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -11650,6 +11672,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "node_modules/styled-components": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.1.tgz",
@@ -11737,6 +11764,45 @@
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/temp": {
@@ -11935,7 +12001,6 @@
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true,
             "engines": {
                 "node": "*"
             }
@@ -12159,10 +12224,9 @@
             }
         },
         "node_modules/unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
             "dependencies": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",
@@ -15914,8 +15978,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "peer": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "batch-processor": {
             "version": "1.0.0",
@@ -15925,8 +15988,7 @@
         "big-integer": {
             "version": "1.6.51",
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "dev": true
+            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
         },
         "bignumber.js": {
             "version": "8.1.1",
@@ -15937,7 +15999,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
             "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-            "dev": true,
             "requires": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
@@ -15953,7 +16014,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "peer": true,
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -15964,7 +16024,6 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "peer": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -15976,8 +16035,7 @@
         "bluebird": {
             "version": "3.4.7",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-            "dev": true
+            "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -16026,7 +16084,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "peer": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -16040,14 +16097,12 @@
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-            "dev": true
+            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="
         },
         "buffers": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-            "dev": true
+            "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
         },
         "bytes": {
             "version": "3.0.0",
@@ -16138,7 +16193,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
             "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-            "dev": true,
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
             }
@@ -16184,6 +16238,11 @@
                     }
                 }
             }
+        },
+        "chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "chroma-js": {
             "version": "2.4.2",
@@ -16882,7 +16941,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
             "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-            "dev": true,
             "requires": {
                 "readable-stream": "^2.0.2"
             }
@@ -16934,7 +16992,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "peer": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -17429,6 +17486,14 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "fast-xml-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+            "requires": {
+                "strnum": "^1.0.5"
+            }
+        },
         "fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -17585,6 +17650,11 @@
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "peer": true
         },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
         "fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -17611,7 +17681,6 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
             "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -17623,7 +17692,6 @@
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
                     "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
@@ -18566,8 +18634,7 @@
         "listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-            "dev": true
+            "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
         },
         "loader-runner": {
             "version": "4.3.0",
@@ -19571,6 +19638,11 @@
                 "minimist": "^1.2.6"
             }
         },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+        },
         "mocha": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
@@ -20319,7 +20391,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "peer": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -21209,8 +21280,7 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "setprototypeof": {
             "version": "1.2.0",
@@ -21690,6 +21760,11 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "styled-components": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.1.tgz",
@@ -21753,6 +21828,41 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+        },
+        "tar-fs": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "temp": {
             "version": "0.8.3",
@@ -21899,8 +22009,7 @@
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-            "dev": true
+            "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
         },
         "ts-loader": {
             "version": "9.4.2",
@@ -22060,10 +22169,9 @@
             }
         },
         "unzipper": {
-            "version": "0.10.11",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-            "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-            "dev": true,
+            "version": "0.10.14",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+            "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
             "requires": {
                 "big-integer": "^1.6.17",
                 "binary": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "splunk",
-    "version": "0.2.10",
+    "version": "0.2.11-beta1",
     "publisher": "Splunk",
     "engines": {
         "vscode": "^1.72.0"
@@ -175,6 +175,32 @@
                     "default": false,
                     "order": 9,
                     "description": "When auto-completing settings, trim whitespace around the '=' sign. For example, key = value will become key=value.\nNote: changing this setting requires a restart of Visual Studio Code."
+                },
+                "splunk.spl2.acceptedTerms": {
+                    "type": "string",
+                    "enum": [
+                        "accepted",
+                        "declined (once)",
+                        "declined (forever)"
+                    ],
+                    "scope": "resource",
+                    "default": "declined (once)",
+                    "order": 10,
+                    "description": "[SPL2] Accepted Splunk General Terms"
+                },
+                "splunk.spl2.javaPath": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 11,
+                    "description": "[SPL2] Java Path"
+                },
+                "splunk.spl2.languageServerVersion": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 12,
+                    "description": "[SPL2] Langauge Server Version"
                 }
             }
         },
@@ -404,12 +430,15 @@
         "@types/vscode-notebook-renderer": "^1.72.0",
         "axios": ">=0.27.2",
         "babel-loader": "^9.1.0",
+        "fast-xml-parser": "^4.2.4",
         "react": "^16",
         "react-dom": "^16.14.0",
         "splunk-sdk": "^1.12.1",
         "styled-components": "5",
+        "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",
-        "typescript": "^4.2.2"
+        "typescript": "^4.2.2",
+        "unzipper": "^0.10.14"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -434,6 +434,7 @@
         "@types/vscode-notebook-renderer": "^1.72.0",
         "axios": ">=0.27.2",
         "babel-loader": "^9.1.0",
+        "extract-zip": "^2.0.1",
         "fast-xml-parser": "^4.2.4",
         "react": "^16",
         "react-dom": "^16.14.0",
@@ -442,7 +443,6 @@
         "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",
         "typescript": "^4.2.2",
-        "unzipper": "^0.10.14",
         "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -193,14 +193,21 @@
                     "scope": "resource",
                     "default": "",
                     "order": 11,
-                    "description": "[SPL2] Java Path"
+                    "description": "[SPL2] Java Path\nSpecify the full path to a Java executable (./java for Mac/Linux or java.exe for Windows). For example, the full path of $JAVA_HOME/bin/java."
+                },
+                "splunk.spl2.languageServerDirectory": {
+                    "type": "string",
+                    "scope": "resource",
+                    "default": "",
+                    "order": 12,
+                    "description": "[SPL2] Language Server Directory\nSpecify the full path of the directory containing SPL2 (Websockets) Langauge Server. Trailing slash not required. Example:\n/Users/<User>/Library/Application Support/Code/User/globalStorage/splunk.splunk/spl2/lsp"
                 },
                 "splunk.spl2.languageServerVersion": {
                     "type": "string",
                     "scope": "resource",
                     "default": "",
-                    "order": 12,
-                    "description": "[SPL2] Langauge Server Version"
+                    "order": 13,
+                    "description": "[SPL2] Language Server Version\nSpecify the version of the SPL2 language server which will be used to create the path to invoke the server. Example, a value of '2.0.362' will invoke spl-lang-server-sockets-2.0.362-all.jar"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
                 ]
             },
             {
+                "id": "splunk_spl2",
+                "aliases": [
+                    "SPL2"
+                ],
+                "configuration": "./spl2-language-configuration.json",
+                "extensions": [
+                    ".spl2"
+                ]
+            },
+            {
                 "id": "splunk-spl-meta",
                 "aliases": [
                     "SPL-META"
@@ -69,6 +79,11 @@
                 "language": "splunk",
                 "scopeName": "source.splunk",
                 "path": "./syntaxes/splunk.tmLanguage.json"
+            },
+            {
+                "language": "splunk_spl2",
+                "scopeName": "source.spl2",
+                "path": "./syntaxes/spl2.tmGrammar.json"
             }
         ],
         "jsonValidation": [
@@ -330,6 +345,19 @@
                 "selector": [
                     {
                         "filenamePattern": "*.splnb"
+                    }
+                ]
+            },
+            {
+                "id": "spl2-notebook",
+                "type": "spl2-notebook",
+                "displayName": "SPL2 Notebook",
+                "selector": [
+                    {
+                        "filenamePattern": "*.spl2nb"
+                    },
+                    {
+                        "filenamePattern": "modules.json"
                     }
                 ]
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "splunk",
-    "version": "0.2.11-beta1",
+    "version": "0.2.10",
     "publisher": "Splunk",
     "engines": {
         "vscode": "^1.72.0"
@@ -361,6 +361,10 @@
             {
                 "command": "splunk.notebooks.copyDetection",
                 "title": "Copy Detection"
+            },
+            {
+                "command": "splunk.restartSpl2LanguageServer",
+                "title": "Restart SPL2 Language Server"
             }
         ],
         "notebooks": [
@@ -438,7 +442,8 @@
         "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",
         "typescript": "^4.2.2",
-        "unzipper": "^0.10.14"
+        "unzipper": "^0.10.14",
+        "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",

--- a/spl2-language-configuration.json
+++ b/spl2-language-configuration.json
@@ -1,0 +1,45 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*/\\*\\*(?!/)([^*]|\\*(?!/))*$",
+      "afterText": "^\\s*\\*/$",
+      "action": {
+        "indent": "indentOutdent",
+        "appendText": " * "
+      }
+    },
+    {
+      "beforeText": "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$",
+      "action": {
+        "indent": "none",
+        "appendText": " * "
+      }
+    },
+    {
+      "beforeText": "^(\t|[ ])*[ ]\\*([ ]([^*]|\\*(?!/))*)?$",
+      "oneLineAboveText": "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))/",
+      "action": {
+        "indent": "none",
+        "appendText": "* "
+      }
+    },
+    {
+      "beforeText": "^(\t|[ ])*[ ]\\*/\\s*$",
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    },
+    {
+      "beforeText": "^(\t|[ ])*[ ]\\*[^/]*\\*/\\s*$",
+      "action": {
+        "indent": "none",
+        "removeText": 1
+      }
+    }
+  ]
+}

--- a/syntaxes/spl2.tmGrammar.json
+++ b/syntaxes/spl2.tmGrammar.json
@@ -1,0 +1,67 @@
+{
+  "scopeName": "source.spl2",
+  "patterns": [
+    {
+      "include": "#block_comment"
+    },
+    {
+      "include": "#line_comment"
+    },
+    {
+      "include": "#expression"
+    }
+  ],
+  "repository": {
+    "block_comment": {
+      "name": "comment.block.spl2",
+      "begin": "/\\*",
+      "end": "\\*/"
+    },
+    "line_comment": {
+      "name": "comment.line.double-slash.spl2",
+      "begin": "//",
+      "end": "$"
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#keyword"
+        },
+        {
+          "include": "#param"
+        },
+        {
+          "include": "#paren-expression"
+        }
+      ]
+    },
+    "keyword": {
+      "match": "\\b(between|BETWEEN|is|IS|like|LIKE'|and|AND|in|IN|not|NOT|or|OR|xor|XOR|after|apply|as|AS|asc|ASC|before|bin|branch|by|BY|dedup|desc|DESC|distinct|DISTINCT|eval|eventstats|exists|EXISTS|export|false|fit|from|FROM|function|group|GROUP|groupby|GROUPBY|having|HAVING|head|histperc|import|inner|INNER|into|join|JOIN|left|LEFT|limit|LIMIT|lookup|null|NULL|offset|OFFSET|on|ON|onchange|order|ORDER|orderby|ORDERBY|outer|OUTER|OUTPUT|OUTPUTNEW|rename|reset|return|rex|search|select|SELECT|sort|stats|streamstats|through|thru|timechart|timewrap|true|type|union|UNION|where|WHERE|while)\\b",
+      "name": "keyword"
+    },
+    "param": {
+      "match": "\\$[a-zA-Z0-9]+",
+      "name": "variable"
+    },
+    "paren-expression": {
+      "begin": "\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.paren.open"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.paren.close"
+        }
+      },
+      "name": "expression.group",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add support for SPL2 notebooks for customers with access to SPL2 preview deployments.

There is a full wiki page that I've staged to help with setup including some notes for existing SPL Notebooks: https://github.com/fantavlik/vscode-extension-splunk/wiki/Splunk-Notebooks

Features:
* Guided installation of SPL2 Language Server and Java 17+ (if needed). More details: https://github.com/splunk/vscode-extension-splunk/pull/86
* Ability to execute SPL2 notebooks cells via `spl2-module-dispatch` endpoint and view job results. More details: https://github.com/splunk/vscode-extension-splunk/pull/85
* Support for SPL2 Language Server and Client initialization when `.spl2nb` or `modules.json` files are opened which provides syntax highlighting, autocomplete, hover documentation, code suggestions, and other language server features. More details: https://github.com/splunk/vscode-extension-splunk/pull/87