### PR TITLE
Allow updating SPL2 modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
       - main
       - master
       - develop
-      - spl2
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
       - main
       - master
       - develop
+      - spl2
 
 jobs:
   build:

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -146,11 +146,15 @@ async function updateModule(cell: vscode.NotebookCell) {
             service,
             <Spl2ModuleCell>{
                 name: cellMetadata?.splunk?.moduleName || `_default`,
-                namespace: cellMetadata?.splunk?.namespace || '',
+                namespace: cellMetadata?.splunk?.namespace || 'apps.search',
                 definition: cell.document.getText(),
             });
     } catch (err) {
-        vscode.window.showErrorMessage(`Issue updating module: ${err}`);
+        if (err?.data?.messages !== undefined) {
+            vscode.window.showErrorMessage(`Issue updating module: ${JSON.stringify(err.data.messages)}`);
+        } else {
+            vscode.window.showErrorMessage(`Issue updating module: ${err}`);
+        }
     }
 }
 
@@ -199,7 +203,7 @@ async function enterModuleName(cell: vscode.NotebookCell) {
         {
             title: 'Module name',
             value: cellMetadata.splunk.moduleName || '_default',
-            prompt: 'Modules should only contain alphanumeric characters and underscores (_)',
+            prompt: 'Module name (except for `_default` module) must start with a lowercase letter followed by digits, lowercase letters and underscore',
         },
     );
 }

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { SplunkController } from './controller';
-import { Spl2ModuleCell } from './spl2/serializer';
 import { VIZ_TYPES } from './visualizations';
 import { getClient, getJobSearchLog, getSearchJobBySid, updateSpl2Module } from './splunk';
 
@@ -142,13 +141,13 @@ async function updateModule(cell: vscode.NotebookCell) {
 
     try {
         const service = getClient();
+
         await updateSpl2Module(
             service,
-            <Spl2ModuleCell>{
-                name: cellMetadata?.splunk?.moduleName || `_default`,
-                namespace: cellMetadata?.splunk?.namespace || 'apps.search',
-                definition: cell.document.getText(),
-            });
+            cellMetadata?.splunk?.moduleName || `_default`,
+            cellMetadata?.splunk?.namespace || 'apps.search',
+            cell.document.getText(),
+        );
     } catch (err) {
         if (err?.data?.messages !== undefined) {
             vscode.window.showErrorMessage(`Issue updating module: ${JSON.stringify(err.data.messages)}`);

--- a/out/notebooks/commands.ts
+++ b/out/notebooks/commands.ts
@@ -191,68 +191,48 @@ async function recordInput(
 }
 
 async function enterModuleName(cell: vscode.NotebookCell) {
-    const cellMetadata = { ...cell.metadata };
-    if (!cellMetadata.splunk) {
-        cellMetadata.splunk = {};
-    }
-
     await recordInput(
         cell,
         'moduleName',
         {
             title: 'Module name',
-            value: cellMetadata.splunk.moduleName || '_default',
+            value: cell?.metadata?.splunk?.moduleName || '_default',
             prompt: 'Module name (except for `_default` module) must start with a lowercase letter followed by digits, lowercase letters and underscore',
         },
     );
 }
 
 async function enterNamespace(cell: vscode.NotebookCell) {
-    const cellMetadata = { ...cell.metadata };
-    if (!cellMetadata.splunk) {
-        cellMetadata.splunk = {};
-    }
-
     await recordInput(
         cell,
         'namespace',
         {
             title: 'Namespace',
-            value: cellMetadata.splunk.namespace || 'apps.search',
+            value: cell?.metadata?.splunk?.namespace || 'apps.search',
             prompt: 'e.g. apps.search, apps.my_app, [blank], etc',
         },
     );
 }
 
 async function enterEarliestTime(cell: vscode.NotebookCell) {
-    const cellMetadata = { ...cell.metadata };
-    if (!cellMetadata.splunk) {
-        cellMetadata.splunk = {};
-    }
-
     await recordInput(
         cell,
         'earliestTime',
         {
             title: 'Earliest time',
-            value: cellMetadata.splunk.earliestTime || '-24h',
+            value: cell?.metadata?.splunk?.earliestTime || '-24h',
             prompt: 'e.g. -24h, @d, -2d@d+2h, 1687909025',
         },
     );
 }
 
 async function enterLatestTime(cell: vscode.NotebookCell) {
-    const cellMetadata = { ...cell.metadata };
-    if (!cellMetadata.splunk) {
-        cellMetadata.splunk = {};
-    }
-
     await recordInput(
         cell,
         'latestTime',
         {
             title: 'Latest time',
-            value: cellMetadata.splunk.latestTime || 'now',
+            value: cell?.metadata?.splunk?.latestTime || 'now',
             prompt: 'e.g. now, -24h, @d, -2d@d+2h, 1687909025',
         },
     );

--- a/out/notebooks/provider.ts
+++ b/out/notebooks/provider.ts
@@ -38,6 +38,17 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
             },
         });
 
+        const moduleUpdateButton = {
+            text: '$(cloud-upload)',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Update module (Splunk deployment)',
+            command: {
+                title: 'Update module (Splunk deployment)',
+                command: 'splunk.notebooks.updateModule',
+                arguments: [cell],
+            },
+        };
+
         const moduleNamePicker = {
             text: '$(edit)',
             alignment: vscode.NotebookCellStatusBarAlignment.Right,
@@ -83,6 +94,7 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
         };
         // earliest and latest time pickers are only supported for SPL2 at the moment
         if (cell.document.languageId === 'splunk_spl2') {
+            items.push(moduleUpdateButton);
             items.push(moduleNamePicker);
             items.push(namespacePicker);
             items.push(earliestPicker);
@@ -117,6 +129,7 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
                     });
                     // earliest and latest time pickers are only supported for SPL2 at the moment
                     if (cell.document.languageId === 'splunk_spl2') {
+                        items.push(moduleUpdateButton);
                         items.push(moduleNamePicker);
                         items.push(namespacePicker);
                         items.push(earliestPicker);

--- a/out/notebooks/provider.ts
+++ b/out/notebooks/provider.ts
@@ -38,6 +38,28 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
             },
         });
 
+        const moduleNamePicker = {
+            text: '$(edit)',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Module name',
+            command: {
+                title: 'Enter module name',
+                command: 'splunk.notebooks.enterModuleName',
+                arguments: [cell],
+            },
+        };
+
+        const namespacePicker = {
+            text: '$(preserve-case)',
+            alignment: vscode.NotebookCellStatusBarAlignment.Right,
+            tooltip: 'Namespace',
+            command: {
+                title: 'Enter namespace',
+                command: 'splunk.notebooks.enterNamespace',
+                arguments: [cell],
+            },
+        };
+
         const earliestPicker = {
             text: 'earliest',
             alignment: vscode.NotebookCellStatusBarAlignment.Right,
@@ -61,6 +83,8 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
         };
         // earliest and latest time pickers are only supported for SPL2 at the moment
         if (cell.document.languageId === 'splunk_spl2') {
+            items.push(moduleNamePicker);
+            items.push(namespacePicker);
             items.push(earliestPicker);
             items.push(latestPicker);
         }
@@ -93,6 +117,8 @@ export class CellResultCountStatusBarProvider implements vscode.NotebookCellStat
                     });
                     // earliest and latest time pickers are only supported for SPL2 at the moment
                     if (cell.document.languageId === 'splunk_spl2') {
+                        items.push(moduleNamePicker);
+                        items.push(namespacePicker);
                         items.push(earliestPicker);
                         items.push(latestPicker);
                     }

--- a/out/notebooks/serializers.ts
+++ b/out/notebooks/serializers.ts
@@ -56,7 +56,7 @@ export class SplunkNotebookSerializer implements vscode.NotebookSerializer {
 
         try {
             raw = <RawNotebookCell[]>JSON.parse(contents);
-        } catch {
+        } catch (err) {
             raw = [];
         }
 

--- a/out/notebooks/spl2/controller.ts
+++ b/out/notebooks/spl2/controller.ts
@@ -6,6 +6,7 @@ import {
 } from '../splunk';
 import { SplunkController } from '../controller';
 import { splunkMessagesToOutputItems } from '../utils';
+import { getAppSubNamespace } from './serializer';
 
 export class Spl2Controller extends SplunkController {
     constructor() {
@@ -30,14 +31,21 @@ export class Spl2Controller extends SplunkController {
 
         const spl2Module = cell.document.getText().trim();
         const service = getClient();
+        let fullNamespace: string = cell?.metadata?.splunk?.namespace || '';
+        // Get apps.<app>[.optional.sub.namespaces] from fullNamespace
+        const [app, subNamespace] = getAppSubNamespace(fullNamespace);
+        const earliest = cell?.metadata?.splunk?.earliestTime;
+        const latest = cell?.metadata?.splunk?.latestTime;
     
         let job;
         try {
             job = await dispatchSpl2Module(
                 service,
                 spl2Module,
-                cell?.metadata?.splunk?.earliestTime,
-                cell?.metadata?.splunk?.latestTime,
+                app,
+                subNamespace,
+                earliest,
+                latest,
             );
             await super._finishExecution(job, cell, execution);
         } catch (failedResponse) {

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -15,7 +15,7 @@ interface Spl2ModulesJson {
     app: string, // hardcoded to apps.search for now
 }
 
-export interface Spl2ModuleCell {
+interface Spl2ModuleCell {
     name: string; // hardcoded to module1, module2, etc for now
     namespace: string; // hardcoded to "" for now
     definition: string; // SPL2 statements
@@ -23,6 +23,26 @@ export interface Spl2ModuleCell {
         metadata: { [key: string]: any };
         outputs?: RawCellOutput[];
     };
+}
+
+/**
+ * Utility function to extract apps.<app>.[sub.name.spaces] from full namespace
+ * @param fullNamespace Full namespace to use for extraction
+ * @returns Two element array containing [app, subnamespace] if fullNamespace matches
+ *   apps.<app>.[sub.name.spaces], otherwise default to ['search', '']
+ */
+export function getAppSubNamespace(fullNamespace: string): [string, string] {
+    let app: string = 'search'; // default
+    let subNamespace: string = ''; // default
+    if (fullNamespace.startsWith('apps.')) {
+        // Find <app> from apps.<app>[.optional.sub.namespaces]
+        let secondDotIndx = fullNamespace.indexOf('.', 'apps.'.length);
+        secondDotIndx = secondDotIndx < 0 ? fullNamespace.length : secondDotIndx;
+        app = fullNamespace.substring('apps.'.length, secondDotIndx);
+        // Find .optional.sub.namespaces from apps.<app>[.optional.sub.namespaces]
+        subNamespace = fullNamespace.substring(secondDotIndx + 1, fullNamespace.length);
+    }
+    return [app, subNamespace];
 }
 
 export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
@@ -39,8 +59,7 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
         } catch (err) {
             raw = <Spl2ModulesJson>{
                 modules: [],
-                // TODO: make the app configurable rather than hardcoding to 'search'
-                app: "apps.search",
+                app: 'apps.search', // default
             };
         }
 
@@ -62,13 +81,16 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
     ): Promise<Uint8Array> {
         let contents: Spl2ModulesJson = <Spl2ModulesJson>{
             modules: [],
-            // TODO: make the app configurable rather than hardcoding to 'search'
-            app: "apps.search",
+            app: 'apps.search', // default
         };
 
         let indx = 1;
         for (const cell of data.cells) {
             const metadata = cell.metadata || {};
+            if (metadata?.splunk?.namespace !== undefined) {
+                // Attempt to read app from namespace
+                contents.app = `apps.${getAppSubNamespace(metadata?.splunk?.namespace)[0]}`;
+            }
             contents.modules.push(<Spl2ModuleCell>{
                 name: metadata?.splunk?.moduleName || `module${indx++}`,
                 namespace: metadata?.splunk?.namespace || "",

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -36,7 +36,7 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
 
         try {
             raw = <Spl2ModulesJson>JSON.parse(contents);
-        } catch {
+        } catch (err) {
             raw = <Spl2ModulesJson>{
                 modules: [],
                 app: "apps.search",

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -15,7 +15,7 @@ interface Spl2ModulesJson {
     app: string, // hardcoded to apps.search for now
 }
 
-interface Spl2ModuleCell {
+export interface Spl2ModuleCell {
     name: string; // hardcoded to module1, module2, etc for now
     namespace: string; // hardcoded to "" for now
     definition: string; // SPL2 statements
@@ -39,6 +39,7 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
         } catch (err) {
             raw = <Spl2ModulesJson>{
                 modules: [],
+                // TODO: make the app configurable rather than hardcoding to 'search'
                 app: "apps.search",
             };
         }
@@ -61,6 +62,7 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
     ): Promise<Uint8Array> {
         let contents: Spl2ModulesJson = <Spl2ModulesJson>{
             modules: [],
+            // TODO: make the app configurable rather than hardcoding to 'search'
             app: "apps.search",
         };
 

--- a/out/notebooks/spl2/serializer.ts
+++ b/out/notebooks/spl2/serializer.ts
@@ -19,7 +19,7 @@ export interface Spl2ModuleCell {
     name: string; // hardcoded to module1, module2, etc for now
     namespace: string; // hardcoded to "" for now
     definition: string; // SPL2 statements
-    _vscode: {
+    _vscode?: {
         metadata: { [key: string]: any };
         outputs?: RawCellOutput[];
     };
@@ -68,9 +68,10 @@ export class Spl2NotebookSerializer implements vscode.NotebookSerializer {
 
         let indx = 1;
         for (const cell of data.cells) {
+            const metadata = cell.metadata || {};
             contents.modules.push(<Spl2ModuleCell>{
-                name: `module${indx++}`,
-                namespace: "",
+                name: metadata?.splunk?.moduleName || `module${indx++}`,
+                namespace: metadata?.splunk?.namespace || "",
                 definition: cell.value,
                 _vscode: {
                     metadata: cell.metadata,

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -2,7 +2,6 @@ import * as splunk from 'splunk-sdk';
 import * as needle from 'needle'; // transitive dependency of splunk-sdk
 import * as vscode from 'vscode';
 import { SplunkMessage } from './utils';
-import { ThrowStatement } from 'typescript';
 
 export function getClient() {
     const config = vscode.workspace.getConfiguration();
@@ -177,7 +176,7 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
         });
 }
 
-function handleErrorPayloads(data: any): ThrowStatement {
+function handleErrorPayloads(data: any) {
     // Response is not in expected successful format, let's handle a
     // few different error cases and raise as expected messages format
     let messages:SplunkMessage[] = [];

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -94,7 +94,7 @@ export function updateSpl2Module(service: any, spl2ModuleCell: Spl2ModuleCell) {
                 return;
             }
             // This is in the expected successful response format
-            vscode.window.showInformationMessage(`${data.namespace}.${data.name} updated at ${data.updatedAt}`);
+            vscode.window.showInformationMessage(`Success! ${data.namespace}.${data.name} updated at ${data.updatedAt}`);
         });
 }
 

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -66,7 +66,7 @@ export function updateSpl2Module(service: any, spl2ModuleCell: Spl2ModuleCell) {
     return needle(
         'PUT',
         // example: https://myhost.splunkcloud.com:8089/services/spl2/modules/apps.search._default
-        `${service.prefix}/services/spl2/modules/${spl2ModuleCell.namespace}.${spl2ModuleCell.name}`,
+        `${service.prefix}/services/spl2/modules/${encodeURIComponent(spl2ModuleCell.namespace)}.${encodeURIComponent(spl2ModuleCell.name)}`,
         {
             'name': spl2ModuleCell.name,
             'namespace': spl2ModuleCell.namespace,

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -114,7 +114,10 @@ export function updateSpl2Module(service: any, moduleName: string, namespace: st
  * @returns A Promise containing the job id created (or throw an Error containing data.messages[])
  */
 export function dispatchSpl2Module(service: any, spl2Module: string, app: string, namespace: string, earliest: string, latest: string) {
-    app = app || 'search';
+    // For now we're using /services/<app> which doesn't respect relative namespaces,
+    // so for now hardcode this to '' but if/when /servicesNS/<app>
+    namespace = '';
+    app = app || 'search'; // default to search app
     // Get last statement assignment '$my_statement = ...' -> 'my_statement' 
     const statementMatches = [...spl2Module.matchAll(/\$([a-zA-Z0-9_]+)[\s]*=/gm)];
     if (!statementMatches

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -57,6 +57,18 @@ export function createSearchJob(jobs, query, options) {
 }
 
 /**
+ * Helper function to create Authorization and Content-Type headers
+ * @param service A Javascript SDK Service instance
+ * @returns An object reflecting Authorization and Content-Type headers
+ */
+function makeHeaders(service: any): object {
+    return {
+        'Authorization': `Bearer ${service.sessionKey}`,
+        'Content-Type': 'application/json',
+    };
+}
+
+/**
  * Update a module by calling the PUT /services/spl2/modules/<namespace>.<moduleName>
  * @param service Instance of the Javascript SDK Service
  * @param moduleName Name of the module to append to the namespace to form the request path
@@ -78,10 +90,7 @@ export function updateSpl2Module(service: any, moduleName: string, namespace: st
             'definition': module,
         },
         {
-            'headers': {
-                'Authorization': `Bearer ${service.sessionKey}`,
-                'Content-Type': 'application/json',
-            },
+            'headers': makeHeaders(service),
             'followAllRedirects': true,
             'timeout': 0,
             'strictSSL': false,
@@ -89,7 +98,8 @@ export function updateSpl2Module(service: any, moduleName: string, namespace: st
         })
         .then((response) => {
             const data = response.body;
-            if (!Object.prototype.isPrototypeOf(data)
+            if (response.statusCode >= 400 ||
+                !Object.prototype.isPrototypeOf(data)
                 || data.name === undefined
                 || data.namespace === undefined
                 || data.definition === undefined
@@ -158,10 +168,7 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
             }
         },
         {
-            'headers': {
-                'Authorization': `Bearer ${service.sessionKey}`,
-                'Content-Type': 'application/json',
-            },
+            'headers': makeHeaders(service),
             'followAllRedirects': true,
             'timeout': 0,
             'strictSSL': false,
@@ -169,7 +176,7 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
         })
         .then((response) => {
             const data = response.body;
-            if (!Array.prototype.isPrototypeOf(data) || data.length < 1) {
+            if (response.statusCode >= 400 || !Array.prototype.isPrototypeOf(data) || data.length < 1) {
                 handleErrorPayloads(data);
                 return;
             }


### PR DESCRIPTION
Provide functionality to input the module name and namespace for SPL2 notebooks and use that information when dispatching SPL2 (detect app and namespace from `apps.<app>` and subnamespace from `apps.<app>.my.sub.namespace`).
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/ec8ff825-df03-4297-81a0-3edde9391dcf)
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/5a07e8b3-60d4-40b0-9910-f102fda874c6)

And provide a new button update the module contents on the connected Splunk deployment using a PUT to the `/services/spl2/modules/<namespace>.<moduleName>` endpoint:
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/11c39159-6057-4c1e-b976-6bf1e02245d2)


Upon success an info message is provided:
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/71313239-3109-4388-bf70-3a7e03330ba6)


Or an error message popup:
<img width="841" alt="image" src="https://github.com/splunk/vscode-extension-splunk/assets/4960530/93e3d961-540a-4676-8922-8bc01e932c33">
