### PR TITLE
Fix problem with variables in comments

### DIFF
--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -129,7 +129,7 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
     namespace = '';
     app = app || 'search'; // default to search app
     // Get last statement assignment '$my_statement = ...' -> 'my_statement' 
-    const statementMatches = [...spl2Module.matchAll(/\$([a-zA-Z0-9_]+)[\s]*=/gm)];
+    const statementMatches = [...spl2Module.matchAll(/^\s*\$([a-zA-Z0-9_]+)[\s]*=/gm)];
     if (!statementMatches
         || statementMatches.length < 1
         || statementMatches[statementMatches.length - 1].length < 2) {


### PR DESCRIPTION
The code to detect variables in SPL2 code is a bit primitive at the moment and currently will catch commented-out variables. This tweaks the regex to require a variable to occur at the start of the line with just whitespace before it.