### PR TITLE
Upgrading jar used by LSP to 2.0.366

### DIFF
--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -496,7 +496,7 @@ export async function getLatestSpl2Release(context: ExtensionContext, progressBa
     return new Promise(async (resolve, reject) => {
         const lspArtifactPath = getLocalLspDir(context);
         // TODO: Remove this hardcoded version/update time and check for updates
-        let latestLspVersion: string = '2.0.362'; // context.globalState.get(stateKeyLatestLspVersion) || "";
+        let latestLspVersion: string = '2.0.366'; // context.globalState.get(stateKeyLatestLspVersion) || "";
         const lastUpdateMs: number = Date.now(); // context.globalState.get(stateKeyLastLspCheck) || 0;
         // Don't check for new version of SPL2 Language Server if less than 24 hours since last check
         if (Date.now() - lastUpdateMs > 24 * 60 * 60 * 1000) {


### PR DESCRIPTION
Splunk VSCode extension currently hardcodes the version we use for LSP, and recently the LSP jar was updated to fix various bugs such as with the `iplocation` command requiring the `prefix` argument in embedded SPL1 queries (even though this is actually not necessary). This jar also adds support for single-line comments as well as various other fixes.

These changes are necessary for SPL2's .conf23 workshop.