### PR TITLE
Fix issue with rmdir failing when directory not empty for some users

### DIFF
--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -115,7 +115,7 @@ export async function installMissingSpl2Requirements(globalStoragePath: string, 
                 }
                 // Remove any existing LSP artifacts first
                 const localLspDir = getLocalLspDir(globalStoragePath);
-                fs.rmdirSync(localLspDir, { recursive: true });
+                fs.rmSync(localLspDir, { recursive: true, force: true });
                 makeLocalStorage(globalStoragePath); // recreate directory
             
                 await getLatestSpl2Release(globalStoragePath, progressBar);
@@ -141,7 +141,7 @@ export async function installMissingSpl2Requirements(globalStoragePath: string, 
             // Remove any old artifacts first
             const localJdkDir = path.join(globalStoragePath, 'spl2', 'jdk');
             try {
-                fs.rmdirSync(localJdkDir, { recursive: true });
+                fs.rmSync(localJdkDir, { recursive: true, force: true });
                 makeLocalStorage(globalStoragePath); // recreate directory
 
                 javaLoc = await installJDK(localJdkDir, progressBar);

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -80,6 +80,13 @@ export function updateSpl2Module(service: any, moduleName: string, namespace: st
     // The Splunk SDK for Javascript doesn't currently support the spl2/modules endpoints
     // nor does it support sending requests in JSON format (only receiving responses), so
     // for now use the underlying needle library that the SDK uses for requests/responses
+    console.log(`Request: [PUT] to ${service.prefix}/services/spl2/modules/${encodeURIComponent(namespace)}.${encodeURIComponent(moduleName)}`);
+    console.log(`Request Body: \n'${JSON.stringify({
+        'name': moduleName,
+        'namespace': namespace,
+        'definition': module,
+    })}'`);
+    console.log(`Request Headers: ${JSON.stringify(makeHeaders(service))}`);
     return needle(
         'PUT',
         // example: https://myhost.splunkcloud.com:8089/services/spl2/modules/apps.search._default
@@ -97,6 +104,8 @@ export function updateSpl2Module(service: any, moduleName: string, namespace: st
             'rejectUnauthorized' : false,
         })
         .then((response) => {
+            console.log(`Response status code: ${response.statusCode}`);
+            console.log(`Response body: \n'${JSON.stringify(response.body)}'`);
             const data = response.body;
             if (response.statusCode >= 400 ||
                 !Object.prototype.isPrototypeOf(data)
@@ -157,6 +166,15 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
     // The Splunk SDK for Javascript doesn't currently support the spl2-module-dispatch endpoint
     // nor does it support sending requests in JSON format (only receiving responses), so
     // for now use the underlying needle library that the SDK uses for requests/responses
+    console.log(`Request: [POST] to ${service.prefix}/services/${encodeURIComponent(app)}/spl2-module-dispatch`);
+    console.log(`Request Body: \n'${JSON.stringify({
+        'module': spl2Module,
+        'namespace': namespace,
+        'queryParameters': {
+            [statementIdentifier]: params
+        }
+    })}'`);
+    console.log(`Request Headers: ${JSON.stringify(makeHeaders(service))}`);
     return needle(
         'POST',
         `${service.prefix}/services/${encodeURIComponent(app)}/spl2-module-dispatch`,
@@ -172,9 +190,11 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
             'followAllRedirects': true,
             'timeout': 0,
             'strictSSL': false,
-            'rejectUnauthorized' : false,
+            'rejectUnauthorized': false,
         })
         .then((response) => {
+            console.log(`Response status code: ${response.statusCode}`);
+            console.log(`Response body: \n'${JSON.stringify(response.body)}'`);
             const data = response.body;
             if (response.statusCode >= 400 || !Array.prototype.isPrototypeOf(data) || data.length < 1) {
                 handleErrorPayloads(data, response.statusCode);

--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
     "devDependencies": {
         "@types/glob": "^7.1.1",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^12.12.0",
+        "@types/node": "^16",
         "@types/vscode": "^1.72.0",
         "@vscode/test-electron": "^2.3.3",
         "chai": "^4.3.6",


### PR DESCRIPTION
Users were encountering errors with `rmdirSync` failing if the directory was not empty. `rmdirSync` is also deprecated, for `rm -rf` functionality we have moved to `rmSync` with `{ recursive: true, force: true }`.

Also added some additional logging to help debug issues that users encounter.