### PR TITLE
Fix port behavior of URL() in notebooks.

### DIFF
--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -10,7 +10,7 @@ export function getClient() {
 
     let url = new URL(restUrl);
     const scheme = url.protocol.replace(':', '');
-    const port = url.port || protocol == 'https' ? 443 : 80;
+    const port = url.port || scheme === 'https' ? 443 : 80;
     const host = url.hostname;
 
     let service = new splunk.Service({

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -10,7 +10,7 @@ export function getClient() {
 
     let url = new URL(restUrl);
     const scheme = url.protocol.replace(':', '');
-    const port = url.port;
+    const port = url.port || protocol == 'https' ? 443 : 80;
     const host = url.hostname;
 
     let service = new splunk.Service({

--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -10,7 +10,7 @@ export function getClient() {
 
     let url = new URL(restUrl);
     const scheme = url.protocol.replace(':', '');
-    const port = url.port || scheme === 'https' ? 443 : 80;
+    const port = url.port || (scheme === 'https' ? '443' : '80');
     const host = url.hostname;
 
     let service = new splunk.Service({


### PR DESCRIPTION
The JavaScript object URL returns an empty port when using 443 for HTTPS and 80 for HTTP, as per https://developer.mozilla.org/en-US/docs/Web/API/URL/port

This means anyone using Splunkd on port 443 (for example through a reverse proxy), will be unable to connect as the extension will default back to 8089.

Fair warning I havent actually tested this fix, but the logic should be sound.