### PR TITLE
feat: update URL to globalConfig file

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "jsonValidation": [
             {
                 "fileMatch": "globalConfig.json",
-                "url": "https://raw.githubusercontent.com/splunk/addonfactory-ucc-base-ui/main/src/main/webapp/schema/schema.json"
+                "url": "https://raw.githubusercontent.com/splunk/addonfactory-ucc-generator/main/splunk_add_on_ucc_framework/schema/schema.json"
             }
         ],
         "configuration": {


### PR DESCRIPTION
We deprecated UCC base UI repository and moved schema to the UCC generator repository.