### PR TITLE
SPL2 notebooks download/use the latest SPL2 language server by default

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -12,7 +12,7 @@ const splunkCustomCommand = require('./customCommand.js');
 const globalConfigPreview = require('./globalConfigPreview')
 const splunkCustomRESTHandler = require('./customRESTHandler.js')
 const splunkSpec = require("./spec.js");
-const PLACEHOLDER_REGEX = /\<([^\>]+)\>/g
+const PLACEHOLDER_REGEX = /\<([^\>]+)\>/g;
 let specConfigs = {};
 let timeout;
 let diagnosticCollection;

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -77,8 +77,7 @@ export async function startSpl2ClientAndServer(globalStoragePath: string, progre
                 return;
             }
             const lspPath = path.join(getLocalLspDir(globalStoragePath), getLspFilename(lspVersion));
-            
-            const server = new Spl2ClientServer(progressBar, javaPath, lspPath, portToAttempt, onClose);
+            const server = new Spl2ClientServer(progressBar, javaPath, lspVersion, lspPath, portToAttempt, onClose);
             await server.initialize();
             resolve(server);
         } catch (err) {
@@ -90,6 +89,7 @@ export async function startSpl2ClientAndServer(globalStoragePath: string, progre
 export class Spl2ClientServer {
     progressBar: StatusBarItem;
     javaPath: string;
+    lspVersion: string;
     lspPath: string;
     retries: number;
     restarting: boolean;
@@ -101,9 +101,10 @@ export class Spl2ClientServer {
     serverProcess: child_process.ChildProcess;
     socket: Socket;
 
-    constructor(progressBar: StatusBarItem, javaPath: string, lspPath: string, portToAttempt: number, onClose: (nextPort: number) => void) {
+    constructor(progressBar: StatusBarItem, javaPath: string, lspVersion: string, lspPath: string, portToAttempt: number, onClose: (nextPort: number) => void) {
         this.progressBar = progressBar;
         this.javaPath = javaPath;
+        this.lspVersion = lspVersion;
         this.lspPath = lspPath;
         this.retries = 0;
         this.restarting = false;
@@ -116,15 +117,15 @@ export class Spl2ClientServer {
     }
 
     async initialize(): Promise<void> {
-        this.progressBar.text = 'Starting SPL2 Language Server';
+        this.progressBar.text = `Starting SPL2 Language Server v${this.lspVersion}`;
         this.progressBar.show();
         return new Promise(async (resolve, reject) => {
             this.lspPort = await getNextAvailablePort(this.portToAttempt, 10)
                 .catch((err) => {
-                    reject(`Unable to find available port for SPL2 language server, err: ${err}`);
+                    reject(`Unable to find available port for SPL2 language server v${this.lspVersion}, err: ${err}`);
                 }) || -1;
             if (this.lspPort === -1) {
-                reject(`Unable to find available port for SPL2 language server`);
+                reject(`Unable to find available port for SPL2 language server v${this.lspVersion}`);
                 return;
             }
 
@@ -159,11 +160,11 @@ export class Spl2ClientServer {
                         // TODO: implement module resolution
                         return;
                     });
-                    this.progressBar.text = 'SPL2 Language Server Running';
+                    this.progressBar.text = `SPL2 Language Server v${this.lspVersion} Running`;
                 } else if (event.newState === State.Starting) {
-                    this.progressBar.text = 'SPL2 Language Server Starting';
+                    this.progressBar.text = `SPL2 Language Server v${this.lspVersion} Starting`;
                 } else {
-                    this.progressBar.text = 'SPL2 Language Server Stopped';
+                    this.progressBar.text = `SPL2 Language Server v${this.lspVersion} Stopped`;
                 }
                 this.progressBar.show();
             });

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -192,10 +192,10 @@ export class Spl2ClientServer {
                 ];
                 this.serverProcess = child_process.spawn(this.javaPath, javaArgs);
                 if (!this.serverProcess || !this.serverProcess.pid) {
-                    reject(`Launching server with ${this.javaPath} ${javaArgs.join(' ')} failed.`);
+                    reject(`Launching language server v${this.lspVersion} with ${this.javaPath} ${javaArgs.join(' ')} failed.`);
                     return;
                 } else {
-                    console.log(`SPL2 Language Server launched with pid: ${this.serverProcess.pid} and listening on port: ${this.lspPort}`);
+                    console.log(`SPL2 Language Server v${this.lspVersion} launched with pid: ${this.serverProcess.pid} and listening on port: ${this.lspPort}`);
                 }
                 this.serverProcess.stderr.on('data', stderr => {
                     console.warn(`[SPL2 Server]: ${stderr}`);
@@ -218,7 +218,7 @@ export class Spl2ClientServer {
                     console.log(`[SPL2 Server]: ${stdout}`);
                     const lspLog: LSPLog = JSON.parse(stdout);
                     if (lspLog.message.includes('started listening on port')) {
-                        console.log('SPL2 Server is up, starting client...');
+                        console.log(`SPL2 Server v${this.lspVersion} is up, starting client...`);
                         // Ready for client
                         this.socket = new Socket();
     

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -524,7 +524,7 @@ export async function getLatestSpl2Release(globalStoragePath: string, progressBa
         const lspArtifactPath = getLocalLspDir(globalStoragePath);
         const shouldDownloadLatest = workspace.getConfiguration().get(configKeyDownloadLatestSPL2);
         // Used as backup if latest version can't be determined or current version is invalid
-        let lspVersionToInstall = '2.0.401'
+        let lspVersionToInstall = '2.0.402'
         // If user has unchecked the option to always download the latest LSP then
         // check if the current specified version is installed, if not then download it
         const currentLspVersion: string = workspace.getConfiguration().get(configKeyLspVersion);

--- a/out/notebooks/spl2/installer.ts
+++ b/out/notebooks/spl2/installer.ts
@@ -524,7 +524,7 @@ export async function getLatestSpl2Release(globalStoragePath: string, progressBa
         const lspArtifactPath = getLocalLspDir(globalStoragePath);
         const shouldDownloadLatest = workspace.getConfiguration().get(configKeyDownloadLatestSPL2);
         // Used as backup if latest version can't be determined or current version is invalid
-        let lspVersionToInstall = '2.0.402'
+        let lspVersionToInstall = '2.0.401'
         // If user has unchecked the option to always download the latest LSP then
         // check if the current specified version is installed, if not then download it
         const currentLspVersion: string = workspace.getConfiguration().get(configKeyLspVersion);

--- a/package.json
+++ b/package.json
@@ -191,24 +191,31 @@
                 },
                 "splunk.spl2.javaPath": {
                     "type": "string",
-                    "scope": "resource",
+                    "scope": "machine",
                     "default": "",
                     "order": 11,
                     "description": "[SPL2] Java Path\nSpecify the full path to a Java executable (./java for Mac/Linux or java.exe for Windows). For example, the full path of $JAVA_HOME/bin/java."
                 },
                 "splunk.spl2.languageServerDirectory": {
                     "type": "string",
-                    "scope": "resource",
+                    "scope": "machine",
                     "default": "",
                     "order": 12,
                     "description": "[SPL2] Language Server Directory\nSpecify the full path of the directory containing SPL2 (Websockets) Langauge Server. Trailing slash not required. Example:\n/Users/<User>/Library/Application Support/Code/User/globalStorage/splunk.splunk/spl2/lsp"
                 },
                 "splunk.spl2.languageServerVersion": {
                     "type": "string",
-                    "scope": "resource",
+                    "scope": "machine",
                     "default": "",
                     "order": 13,
                     "description": "[SPL2] Language Server Version\nSpecify the version of the SPL2 language server which will be used to create the path to invoke the server. Example, a value of '2.0.362' will invoke spl-lang-server-sockets-2.0.362-all.jar"
+                },
+                "splunk.spl2.downloadLatestSPL2": {
+                    "type": "boolean",
+                    "scope": "machine",
+                    "default": true,
+                    "order": 14,
+                    "description": "[SPL2] Automatically update to the latest version of the SPL2 language server."
                 }
             }
         },


### PR DESCRIPTION
Previously we were hardcoding which version to use. Users can also opt-out of this automatic update and/or hardcode to a specific version of the SPL2 Language server if they like, new setting:
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/06436bb7-afcb-46b7-ab1b-34f31a0d3d32)

In order to make it clear to the user which version of the language server is being used (also helpful for debugging issues for customers) the language server version is now displayed along with the current language server status at the bottom of the SPL2 notebook window:
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/8bcb87bf-f9fd-4bd4-be27-b27f3d820ee6)

[Functional test logs](https://github.com/splunk/vscode-extension-splunk/actions/runs/8347808857/job/22848297222?pr=115#step:7:58) also confirm the latest version is discovered and used (2.0.402 at the time of this PR) by default:
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/84539a6e-e7a7-4a82-aa95-2aaf514c9391)


This PR also addresses an issue some users noticed where their machine-specific installation settings (e.g. local paths to Java or the SPL2 language server) were propagating across their devices. Changing these settings to `scope=machine` should correctly fix those settings to a given device where VSCode is installed.