### PR TITLE
Add support for SPL2 language server for .spl2 files

### DIFF
--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -133,7 +133,7 @@ export class Spl2ClientServer {
             // Options to control the language client
             const clientOptions: LanguageClientOptions = {
                 documentSelector: [
-                    { language: 'splunk_spl2' },
+                    { language: 'splunk_spl2', pattern: '**∕*.spl2'},
                 ],
                 initializationOptions: { profile: null },
             };

--- a/out/notebooks/spl2/initializer.ts
+++ b/out/notebooks/spl2/initializer.ts
@@ -133,6 +133,7 @@ export class Spl2ClientServer {
             // Options to control the language client
             const clientOptions: LanguageClientOptions = {
                 documentSelector: [
+                    { language: 'splunk_spl2' },
                     { language: 'splunk_spl2', pattern: '**∕*.spl2'},
                 ],
                 initializationOptions: { profile: null },


### PR DESCRIPTION
This one-line change adds autocompletion and hover-docs support for all *.spl2 files matching the behavior in SPL2 notebooks:
![image](https://github.com/splunk/vscode-extension-splunk/assets/4960530/ef6074ab-e4b2-4884-8fa7-89fe425287cf)
