### PR TITLE
Refresh newly opened spl2 documents and cells via didOpen.

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -333,13 +333,18 @@ async function handleSpl2Document(context, progressBar) {
     console.log(`handleSpl2Document`);
     if (spl2Client) {
         console.log(`spl2Client detected`);
-        // Client and server are already running, try refreshing for case of new document
-        const range = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1));
-        const text = vscode.window.activeTextEditor.document.getText(range) || " ";
-        vscode.window.activeTextEditor.edit((editBuilder) => {
-            // To refresh language server make a harmless edit by replacing the first character
-            editBuilder.replace(range, text);
-        });
+        // send new didOpen message to refresh language server (even if already open)
+        spl2Client.client.sendRequest(
+            'textDocument/didOpen',
+            {
+                textDocument: {
+                    uri: vscode.window.activeTextEditor.document.uri.toString(),
+                    languageId: vscode.window.activeTextEditor.document.languageId,
+                    version: 1,
+                    text: vscode.window.activeTextEditor.document.getText(),
+                }
+            }
+        );
         return;
     }
     try {


### PR DESCRIPTION
This eliminates the hack that added space (" ") edit to force language server updates across documents which is annoying for users because it makes it appear that all SPL2-related documents have unsaved changes.

Demo of behavior after MR changes:
![didOpen](https://github.com/splunk/vscode-extension-splunk/assets/4960530/fbc0339c-f33c-487e-8500-4122540ab790)
