### PR TITLE
fix: updated version of search endpoint /search/v2/jobs/export

### DIFF
--- a/out/searchProvider.js
+++ b/out/searchProvider.js
@@ -35,7 +35,7 @@ class SearchProvider {
         await axios(
             {
                 method: "POST",
-                url: `${this.splunkUrl}/services/search/jobs/export?output_mode=${this.outputMode}`,
+                url: `${this.splunkUrl}/services/search/v2/jobs/export?output_mode=${this.outputMode}`,
                 data: "search=" + encodeURIComponent(`search ${search}`)
             })
             .then(response => {
@@ -120,7 +120,7 @@ class SavedSearchProvider {
         await axios(
             {
                 method: "POST",
-                url: `${this.splunkUrl}/servicesNS/${savedSearchItem.owner}/${savedSearchItem.app}/search/jobs/export?output_mode=${this.outputMode}`,
+                url: `${this.splunkUrl}/servicesNS/${savedSearchItem.owner}/${savedSearchItem.app}/search/v2/jobs/export?output_mode=${this.outputMode}`,
                 data: "search=" + encodeURIComponent(`| savedsearch "${savedSearchItem.label}"`)
             })
             .then(response => {


### PR DESCRIPTION
The endpoint `/search/jobs/export` is depricated as of Splunk version 9.0.1. Updated to use v2 of endpoint.
Ref https://docs.splunk.com/Documentation/Splunk/9.2.1/RESTREF/RESTsearch#search.2Fjobs.2Fexport_.28deprecated.29