### PR TITLE
Add automatic support for V2 search endpoints

### DIFF
--- a/out/searchProvider.js
+++ b/out/searchProvider.js
@@ -163,6 +163,7 @@ exports.SavedSearch = SavedSearch;
 let cachedDisableV2SearchApi = null; // avoid multiple calls
 async function shouldUseDeprecatedSearchAPIs() {
     if (cachedDisableV2SearchApi !== null) {
+        console.log(`shouldUseDeprecatedSearchAPIs found cachedDisableV2SearchApi=${cachedDisableV2SearchApi}`);
         return cachedDisableV2SearchApi;
     }
     // retrieve Splunk version and deployment info for disableV2SearchApi()
@@ -172,5 +173,6 @@ async function shouldUseDeprecatedSearchAPIs() {
         console.warn(error);
     });
     cachedDisableV2SearchApi = service.disableV2SearchApi();
+    console.log(`shouldUseDeprecatedSearchAPIs service.disableV2SearchApi()=${cachedDisableV2SearchApi}`);
     return cachedDisableV2SearchApi;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "splunk",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "splunk",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.22.8",
@@ -23,7 +23,7 @@
                 "querystring-es3": "^0.2.1",
                 "react": "^16.14.0",
                 "react-dom": "^16.14.0",
-                "splunk-sdk": "^1.12.1",
+                "splunk-sdk": "^2.0.0",
                 "styled-components": "^5.1.1",
                 "tar-fs": "^2.1.1",
                 "ts-loader": "^9.4.2",
@@ -11947,9 +11947,9 @@
             }
         },
         "node_modules/splunk-sdk": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/splunk-sdk/-/splunk-sdk-1.12.1.tgz",
-            "integrity": "sha512-LhXTNYZ6ozGNuCeP8krdZmbrOe89QgfbZcP4SicsfciBRrh64fVRZmkZPoKeLrYvWHEpYv4NjBmDhrjvWQiL4w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/splunk-sdk/-/splunk-sdk-2.0.0.tgz",
+            "integrity": "sha512-xmkoZ1I6KxQrs7B15db5nUqLGDR+ohDZ21/sGfcLRwOYfTCGR8uHVP/huEwTtrSXJ/WcgyevDwnIniOjuKhcOQ==",
             "dependencies": {
                 "cookie": "0.4.2",
                 "dotenv": "16.0.0",

--- a/package.json
+++ b/package.json
@@ -460,7 +460,7 @@
         "querystring-es3": "^0.2.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "splunk-sdk": "^1.12.1",
+        "splunk-sdk": "^2.0.0",
         "styled-components": "^5.1.1",
         "tar-fs": "^2.1.1",
         "ts-loader": "^9.4.2",


### PR DESCRIPTION
Upgrade to v2.0.0 of splunk-sdk-javascript which provides automatic support for v2 search endpoints. For export endpoints (which aren't supported by the SDK at this time) use the SDK to determine which endpoint should be used based on the Splunk version from the /services/server/info endpoint (`service.getInfo()`).