### PR TITLE
SPL2: Relax /dispatch response checking for sid, improve logging

### DIFF
--- a/out/notebooks/splunk.ts
+++ b/out/notebooks/splunk.ts
@@ -144,7 +144,7 @@ export function updateSpl2Module(service: any, moduleName: string, namespace: st
                 || data.definition === undefined
                 || data.updatedAt === undefined
             ) {
-                handleErrorPayloads(data, response.statusCode);
+                handleErrorPayloads(data, response.statusCode, `[${response.statusCode}] response code`);
                 return;
             }
             // This is in the expected successful response format
@@ -225,20 +225,27 @@ export function dispatchSpl2Module(service: any, spl2Module: string, app: string
             console.log(`Response body: \n'${JSON.stringify(response.body)}'`);
             console.log(`Response headers: \n'${JSON.stringify(response.headers)}'`);
             const data = response.body;
-            if ((response.statusCode >= 400) || !Object.prototype.isPrototypeOf(data) || !Object.prototype.isPrototypeOf(data.queryParameters) || !Object.prototype.isPrototypeOf(data.queryParameters[statementIdentifier])) {
-                handleErrorPayloads(data, response.statusCode);
+            if (response.statusCode >= 400) {
+                handleErrorPayloads(data, response.statusCode, `[${response.statusCode}] response code`);
                 return;
             }
             // This is in the expected successful response format
-            const sid = data.queryParameters[statementIdentifier]['sid'];
-            return getSearchJobBySid(service, sid);
+            try {
+                console.log(`Attempting to retrieve sid from statementIdentifier: '${statementIdentifier}'`);
+                const sid = data.queryParameters[statementIdentifier]['sid'];
+                return getSearchJobBySid(service, sid);
+            } catch (err) {
+                console.warn("Error retrieving sid from response.");
+                console.warn(err);
+                handleErrorPayloads(data, response.statusCode, `Unable to retrieve sid from /dispatch response. Error: ${err.message}`);
+            }
         });
 }
 
-function handleErrorPayloads(data: any, statusCode: number) {
+function handleErrorPayloads(data: any, statusCode: number, details: string) {
     // Response is not in expected successful format, let's handle a
     // few different error cases and raise as expected messages format
-    console.warn(`Error making request: ${JSON.stringify(data)}`);
+    console.warn(`Error making request: data='${JSON.stringify(data)}' statusCode=${statusCode} details='${details}'`);
     let messages:SplunkMessage[] = [];
     // Override error messages for common scenarios
     switch(statusCode) {
@@ -270,6 +277,7 @@ function handleErrorPayloads(data: any, statusCode: number) {
                         'type': msg?.attributes?.type,
                         'code': msg.name,
                         'text': msg.value,
+                        'details': details,
                 }));
         } else if (data.code !== undefined && data.message !== undefined) {
             // Reformat if returns a `code` and `message for errors such
@@ -278,6 +286,7 @@ function handleErrorPayloads(data: any, statusCode: number) {
                 'type': 'error',
                 'code': data.code,
                 'text': data.message,
+                'details': details,
             }];
         }
     }
@@ -288,6 +297,7 @@ function handleErrorPayloads(data: any, statusCode: number) {
             'type': 'error',
             'code': '',
             'text': `Error making request: ${JSON.stringify(data)}`,
+            'details': details,
         }];
     }
     throw new Object({

--- a/out/notebooks/utils/messages.ts
+++ b/out/notebooks/utils/messages.ts
@@ -3,7 +3,8 @@ import * as vscode from 'vscode'
 export interface SplunkMessage {
     type: string,
     code: string,
-    text: string
+    text: string,
+    details?: string,
 }
 
 export function splunkMessagesToOutputItems(messages: SplunkMessage[]) : vscode.NotebookCellOutputItem[] {
@@ -13,7 +14,9 @@ export function splunkMessagesToOutputItems(messages: SplunkMessage[]) : vscode.
 export function splunkMessageToOutputItem(message: SplunkMessage) : vscode.NotebookCellOutputItem {
 
     const outputItem = vscode.NotebookCellOutputItem.text(
-        `${message.type}: ${message.code ? message.code + ' - ' : ''} ${message.text}`
+        (message.details == undefined)
+        ? `${message.type}: ${message.code ? message.code + ' - ' : ''} ${message.text}`
+        : `${message.type}: ${message.code ? message.code + ' - ' : ''} ${message.text}. Details: ${message.details}`
     )
     return outputItem
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "splunk",
-    "version": "0.3.5",
+    "version": "0.3.5-rc1",
     "publisher": "Splunk",
     "engines": {
         "vscode": "^1.75.0",


### PR DESCRIPTION
Running into unknown differences in handling SPL2 responses between the 0.3.5 release candidate and the published version of 0.3.5. This relaxes some of the response checking contraints and adds better logging to determine any differences / root cause.